### PR TITLE
Check restore db exists before starting restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ This tool can be used to script the backup of your databases. Move the backup an
 * `--output` - same as `COUCH_OUTPUT`
 * `--mode` - same as `COUCH_MODE`
 
+## Exit Codes
+
+On error, `couchbackup` and `couchrestore` will exit with non-zero exit codes. This section
+details them.
+
+### CouchBackup
+
+* `1`: generic error (sorry if you see this one).
+
+### CouchRestore
+
+* `1`: generic error.
+* `10`: restore target database does not exist.
+
 ## Using programmatically
 
 You can now use `couchbackup` programatically. First install the `couchbackup` into your project

--- a/app.js
+++ b/app.js
@@ -36,17 +36,29 @@ module.exports = {
   },
   restoreStream: function(readStream, opts, callback) {
     opts = mergeDefaults(opts, defaults);
-    return restore(opts.COUCH_URL, opts.COUCH_DATABASE, opts.COUCH_BUFFER_SIZE, opts.COUCH_PARALLELISM, readStream)
-      .on('written', function(obj) {
-        debug(' written ', obj.total);
-      })
-      .on('writeerror', function(e) {
-        debug(' error', e);
-      })
-      .on('writecomplete', function(obj) {
-        debug('restore complete');
-        callback(null, obj);
-      });
+    return restore(
+      opts.COUCH_URL,
+      opts.COUCH_DATABASE,
+      opts.COUCH_BUFFER_SIZE,
+      opts.COUCH_PARALLELISM,
+      readStream,
+      function(err, writer) {
+        if (err) {
+          callback(err, null);
+        }
+
+        writer.on('written', function(obj) {
+          debug(' written ', obj.total);
+        })
+        .on('writeerror', function(e) {
+          debug(' error', e);
+        })
+        .on('writecomplete', function(obj) {
+          debug('restore complete');
+          callback(null, obj);
+        });
+      }
+    );
   },
   backupFile:  function(filename, opts, callback) {
     return this.backupStream(fs.createWriteStream(filename), opts, callback);
@@ -54,4 +66,4 @@ module.exports = {
   restoreFile: function(filename, opts, callback) {
     return this.restoreStream(fs.createReadStream(filename), opts, callback);
   }
-}
+};

--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const debug = require('debug')('couchbackup');
 
 // switch on debug messages
 process.env.DEBUG = "couchbackup";
@@ -7,6 +8,12 @@ var config = require('../includes/config.js'),
   couchbackup = require('../app.js');
 
 // restore from stdin
-couchbackup.restoreStream(process.stdin, config, function() {
-  
+couchbackup.restoreStream(process.stdin, config, function(err, data) {
+  if (err) {
+    debug(`Error: ${err.message}`);
+    var exitCode = {
+      'RestoreDatabaseNotFound': 10
+    }[err.name] || 1;
+    process.exit(exitCode);
+  }
 });

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -1,10 +1,67 @@
-module.exports = function(url, dbname, buffersize, parallelism, readstream) {
-  liner = require('../includes/liner.js'),
-  writer = require('../includes/writer.js')(url, dbname, buffersize, parallelism);
-   
-  // pipe the input to the output, via transformation functions
-  readstream.pipe(liner())        // transform the input stream into per-line 
-    .pipe(writer) // transform the data
- 
-  return writer;
+const url = require('url');
+
+const request = require('request');
+const debug = require('debug')('couchbackup');
+
+module.exports = function(url, dbname, buffersize, parallelism, readstream, callback) {
+  const couchDbUrl = databaseUrl(url, dbname);
+
+  exists(couchDbUrl, function(err, exists) {
+    if (err || !exists) {
+      var e = new Error(`Database ${couchDbUrl} does not exist. ` +
+        'Create the target database before restoring.');
+      e.name = 'RestoreDatabaseNotFound';
+      callback(e, null);
+    }
+
+    debug(`Starting restore to ${couchDbUrl}`);
+
+    var liner = require('../includes/liner.js');
+    var writer = require('../includes/writer.js')(couchDbUrl, buffersize, parallelism);
+
+    // pipe the input to the output, via transformation functions
+    readstream.pipe(liner())        // transform the input stream into per-line 
+      .pipe(writer); // transform the data
+
+    callback(null, writer);
+  });
 };
+
+/*
+  Check couchDbUrl is a valid database URL.
+  @param {string} couchDbUrl - Database URL
+  @param {function(err, exists)} callback - exists is true if database exists
+*/
+function exists(couchDbUrl, callback) {
+  var r = {
+    url: couchDbUrl,
+    method: 'HEAD',
+    json: true
+  };
+  request(r, function(err, res) {
+    if (err) {
+      debug(err);
+      callback(err, false);
+      return;
+    }
+    if (res && res.statusCode !== 200) {
+      callback(null, false);
+    }
+    callback(null, true);
+  });
+}
+
+/*
+  Combine a base URL and a database name, ensuring at least single slash
+  between root and database name. This allows users to have Couch behind
+  proxies that mount Couch's / endpoint at some other mount point.
+  @param {string} root - root URL
+  @param {string} databaseName - database name
+  @return concatenated URL.
+*/
+function databaseUrl(root, databaseName) {
+  if (!root.endsWith('/')) {
+    root = root + '/';
+  }
+  return url.resolve(root, databaseName);
+}

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -2,7 +2,7 @@ var async = require('async'),
     request = require('request'),
     stream = require('stream');
 
-module.exports = function(couch_url, couch_database, buffer_size, parallelism) {
+module.exports = function(couch_db_url, buffer_size, parallelism) {
   
   var buffer = [ ],
     written = 0,
@@ -15,7 +15,7 @@ module.exports = function(couch_url, couch_database, buffer_size, parallelism) {
      payload.new_edits = false;
    }
    var r = {
-     url: couch_url + '/' + couch_database + '/_bulk_docs',
+     url: couch_db_url + '/_bulk_docs',
      method: 'post',
      json: true,
      body: payload


### PR DESCRIPTION
## What

Check restore database exists before attempting to restore data. This prevents couchrestore churning through potentially 100s of GB of restore file and failing all requests made.

## How

Altered the restore function to check that the database exists by making a GET before spooling up the restore task.

In order to do this, I had to alter the signature to accept a callback so the error can be propagated back to the user.

## Testing

I manually tested the fix. We don't seem to have other testing in place right now :/

## Issues

#17 
