### PR TITLE
Combine root and dbname in app.js

### DIFF
--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const liner = require('./liner.js');
 const change = require('./change.js');
 
-module.exports = function(url, dbname, log, resume, blocksize, callback) {
+module.exports = function(dbUrl, log, resume, blocksize, callback) {
   // do nothing if in resume mode
   if (resume) {
     return callback(null, {});
@@ -44,7 +44,7 @@ module.exports = function(url, dbname, log, resume, blocksize, callback) {
   };
 
   // stream the changes feed to disk
-  request(url + '/' + encodeURIComponent(dbname) + '/_changes?seq_interval=10000')
+  request(dbUrl + '/_changes?seq_interval=10000')
     .pipe(liner())
     .pipe(change(onChange))
     .on('finish', function() {


### PR DESCRIPTION
## What

This first step hoists the step of generating the database URL into
app.js rather than each of the backup and restore files. The functions
called by app.js all operate on a single database, so need not have
separate root and dbname supplied.

I'd like to have the app.js functions move away from the ENVIRONMENT_VARS object as they also deal with a single database and it looks odd when using the library functions, but this is a step towards that (#27).

## How

app.js now does all the URL combining to form the database's root URL.

## Testing

Existing tests pass; refactoring.

## Issues

Fixes #26