### PR TITLE
Bump version to 2.0.0-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couchbackup",
-  "version": "1.4.1-SNAPSHOT",
+  "version": "2.0.0-SNAPSHOT",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "repository": "https://github.com/cloudant/couchbackup.git",
   "keywords": [


### PR DESCRIPTION
This allows us to remove old APIs.

## What

Simple package.json change to 2.0.0.

## How

n/a

## Testing

n/a

## Issues

n/a
