### PR TITLE
Use new API in CLI tooling

### DIFF
--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -3,7 +3,19 @@
 
 const config = require('../includes/config.js');
 const error = require('../includes/error.js');
+const cliutils = require('../includes/cliutils.js');
 const couchbackup = require('../app.js');
 
-// restore from stdin
-couchbackup.restoreStream(process.stdin, config, error.terminationCallback);
+// copyIfDefined ensures we don't overwrite defaults for
+// new methods with `undefined`.
+var opts = {};
+cliutils.copyIfDefined(config, 'COUCH_BUFFER_SIZE', opts, 'bufferSize');
+cliutils.copyIfDefined(config, 'COUCH_PARALLELISM', opts, 'parallelism');
+
+// Restore from stdin
+return couchbackup.restore(
+  process.stdin,
+  cliutils.databaseUrl(config.COUCH_URL, config.COUCH_DATABASE),
+  opts,
+  error.terminationCallback
+);

--- a/includes/cliutils.js
+++ b/includes/cliutils.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Utility methods for the command line interface.
+ * @module cliutils
+ * @see module:cliutils
+ */
+
+const url = require('url');
+
+module.exports = {
+
+  /**
+   * Combine a base URL and a database name, ensuring at least single slash
+   * between root and database name. This allows users to have Couch behind
+   * proxies that mount Couch's / endpoint at some other mount point.
+   * @param {string} root - root URL
+   * @param {string} databaseName - database name
+   * @return concatenated URL.
+   *
+   * @private
+   */
+  databaseUrl: function databaseUrl(root, databaseName) {
+    if (!root.endsWith('/')) {
+      root = root + '/';
+    }
+    return url.resolve(root, encodeURIComponent(databaseName));
+  },
+
+  /**
+   * Copy an attribute between objects if it is defined on the source,
+   * overwriting any existing property on the target.
+   *
+   * @param {object} src - source object.
+   * @param {string} srcProperty - source property name.
+   * @param {object} target - target object.
+   * @param {string} targetProperty - target property name.
+   *
+   * @private
+   */
+  copyIfDefined: function copyIfDefined(src, srcProperty, target, targetProperty) {
+    if (typeof src[srcProperty] !== 'undefined') {
+      target[targetProperty] = src[srcProperty];
+    }
+  }
+};


### PR DESCRIPTION
No-one now uses the deprecated API methods in the package.

## What

CLI implementation now uses new APIs rather than deprecated APIs.

## How

Basically copied over the code that implemented the legacy API to new API implementation into the CLI tooling itself, putting shared methods into a `cliutils` module.

## Testing

npm test passes, backup and restore appear to work.

## Issues

Fixes #39
