### PR TITLE
Remove legacy API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - [NEW] Moved to https://github.com/cloudant/couchbackup repository
 - [NEW] API for using as library is more Node.js like.
 - [BREAKING CHANGE] The --buffer option is now --buffer-size.
+- [BREAKING CHANGE] Removed legacy 1.x API.
 - [BREAKING CHANGE] The `writeerror` event is now just `error`.
 - [BREAKING CHANGE] The `writecomplete` event is now `finished`.
 - [BREAKING CHANGE] For restoring, the `written` event is now `restored`.


### PR DESCRIPTION
## What

This removes backupStream, backupFile, restoreStream and restoreFile.

## How

Straightforward code delete.

## Testing

Tests pass, backup/restore doesn't crash.

## Issues

Fixes #40