### PR TITLE
Added gzip encoding for responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,5 +10,7 @@
 - [DEPRECATED] Previous API functions.
 - [IMPROVED] Existence of the restore destination database is checked before
   starting the restore process.
+- [IMPROVED] Added compression for backup HTTP responses, where supported by the
+  server.
 - [FIXED] An issue where the process could exit before the backup content was
   completely flushed to the destination stream.

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -151,7 +151,8 @@ function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal
       qs: { revs: true }, // gets previous revision tokens too
       method: 'post',
       json: true,
-      body: payload
+      body: payload,
+      gzip: true
     };
     request(r, function(err, res, data) {
       if (!err && data && data.results) {

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -24,7 +24,8 @@ module.exports = function(url, dbname, blocksize, parallelism, log, resume, outp
       url: url + '/' + dbname + '/_all_docs',
       method: 'get',
       qs: opts,
-      json: true
+      json: true,
+      gzip: true
     };
     request(r, function(err, res, data) {
       if (err) {

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -52,7 +52,12 @@ module.exports = function(dbUrl, log, blocksize, callback) {
   };
 
   // stream the changes feed to disk
-  request(dbUrl + '/_changes?seq_interval=10000')
+  var r = {
+    url: dbUrl + '/_changes',
+    qs: { seq_interval: 10000 },
+    gzip: true
+  };
+  request(r)
     .pipe(liner())
     .pipe(change(onChange))
     .on('finish', function() {


### PR DESCRIPTION
## What

Enabled `request` `gzip` option for response bodies.

## How

Added `{gzip: true}` option to requests that receive large bodies.

## Testing

No new tests added as just enabling a feature of underlying library. Validation provided by existing tests continuing to pass.
