### PR TITLE
37 write events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,3 +16,5 @@
   completely flushed to the destination stream.
 - [FIXED] An issue where back pressure on the output stream was ignored
   potentially resulting in the backup process running out of memory.
+- [FIXED] An issue where the log entry could be written for a batch before the
+  batch was written to the backup file.

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -145,6 +145,14 @@ function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal
     var thisBatch = payload.batch;
     delete payload.batch;
 
+    function logCompletedBatch(batch) {
+      if (log) {
+        fs.appendFile(log, ':d batch' + thisBatch + '\n', done);
+      } else {
+        done();
+      }
+    }
+
     // do the /db/_bulk_get request
     var r = {
       url: dbUrl + '/_bulk_get',
@@ -168,12 +176,7 @@ function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal
         });
         total += output.length;
         var t = (new Date().getTime() - start) / 1000;
-        ee.emit('received', {length: output.length, time: t, total: total, data: output, batch: thisBatch}, q);
-        if (log) {
-          fs.appendFile(log, ':d batch' + thisBatch + '\n', done);
-        } else {
-          done();
-        }
+        ee.emit('received', {length: output.length, time: t, total: total, data: output, batch: thisBatch}, q, logCompletedBatch);
       } else {
         ee.emit('error', err);
         done();


### PR DESCRIPTION
## What

Improved write event semantics

## How

* Moved the `written` event to emit *after* the batch content has been flushed.
Currently the call to emit the `written` event happens after the call to write to the `targetStream` this means the event is emitted regardless of the state of the data that has been written to the stream. The `write` function optionally accepts a callback which is invoked after the data has been flushed to the stream, which means that we can emit the event after the data is *actually* written, rather than after we have *asked* for it to be written.

* Added a callback to write the log entry *after* the batch has flushed to the backup file.
Currently the `backup` writes to the log file that a batch is complete immediately after receiving the batch from the server. However, the implementation sends that batch (via the `received` event) to the `app` for writing to the target stream. This leaves a large window where the log file can record a batch as done, but where the batch has not yet been processed by the `app` or flushed to the backup stream/file. The log file should not be written until after the data has made it to disk, so by passing a callback from the `backup` to the `app` then after the flush has happened the `app` can callback to the `backup` and at that point it can write the log file.

## Testing

No new tests specifically for this issue, existing tests pass.

## Issues

Fixes #37 

