### PR TITLE
69 keep alive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
   starting the restore process.
 - [IMPROVED] Added compression for backup HTTP responses, where supported by the
   server.
+- [IMPROVED] Added HTTP persistent connection pools corresponding to the backup
+  parallelism.  
 - [FIXED] An issue where the process could exit before the backup content was
   completely flushed to the destination stream.
 - [FIXED] An issue where back pressure on the output stream was ignored

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -137,6 +137,7 @@ function readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, ee, callback
  * @param {any} callback - completion callback, (err, {total: number}).
  */
 function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal, callback) {
+  const client = request.client(dbUrl, parallelism);
   var total = grandtotal;
 
   // queue to process the fetch requests in an orderly fashion using _bulk_get
@@ -158,11 +159,9 @@ function processBatchSet(dbUrl, parallelism, log, batches, ee, start, grandtotal
       url: dbUrl + '/_bulk_get',
       qs: { revs: true }, // gets previous revision tokens too
       method: 'post',
-      json: true,
-      body: payload,
-      gzip: true
+      body: payload
     };
-    request(r, function(err, res, data) {
+    client(r, function(err, res, data) {
       if (!err && data && data.results) {
         // create an output array with the docs returned
         data.results.forEach(function(d) {

--- a/includes/request.js
+++ b/includes/request.js
@@ -1,9 +1,25 @@
 'use strict';
 
 const pkg = require('../package.json');
+const http = require('http');
+const https = require('https');
 const request = require('request');
 
 const userAgent = 'couchbackup-cloudant/' + pkg.version + ' (Node.js ' +
       process.version + ')';
 
-module.exports = request.defaults({headers: {'User-Agent': userAgent}});
+module.exports = {
+  client: function(url, parallelism) {
+    var protocol = (url.match(/^https/)) ? https : http;
+    const keepAliveAgent = new protocol.Agent({
+      keepAlive: true,
+      keepAliveMsecs: 30000,
+      maxSockets: parallelism
+    });
+    return request.defaults({
+      agent: keepAliveAgent,
+      headers: {'User-Agent': userAgent},
+      json: true,
+      gzip: true});
+  }
+};

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -33,10 +33,10 @@ module.exports = function(dbUrl, buffersize, parallelism, readstream, callback) 
 function exists(dbUrl, callback) {
   var r = {
     url: dbUrl,
-    method: 'HEAD',
-    json: true
+    method: 'HEAD'
   };
-  request(r, function(err, res) {
+  const client = request.client(dbUrl, 1);
+  client(r, function(err, res) {
     if (err) {
       debug(err);
       callback(err, false);

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -4,6 +4,7 @@ const async = require('async');
 const request = require('./request.js');
 
 module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
+  const client = request.client(dbUrl, parallelism);
   if (typeof blocksize === 'string') {
     blocksize = parseInt(blocksize);
   }
@@ -23,11 +24,9 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
     var r = {
       url: dbUrl + '/_all_docs',
       method: 'get',
-      qs: opts,
-      json: true,
-      gzip: true
+      qs: opts
     };
-    request(r, function(err, res, data) {
+    client(r, function(err, res, data) {
       if (err) {
         ee.emit('error', err);
         return callback(null, null);

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -17,6 +17,8 @@ const change = require('./change.js');
  *  of batches and doccount is total number of changes found.
  */
 module.exports = function(dbUrl, log, blocksize, callback) {
+  const client = request.client(dbUrl, 1);
+
   // list of document ids to process
   var buffer = [];
   var batch = 0;
@@ -54,10 +56,9 @@ module.exports = function(dbUrl, log, blocksize, callback) {
   // stream the changes feed to disk
   var r = {
     url: dbUrl + '/_changes',
-    qs: { seq_interval: 10000 },
-    gzip: true
+    qs: { seq_interval: 10000 }
   };
-  request(r)
+  client(r)
     .pipe(liner())
     .pipe(change(onChange))
     .on('finish', function() {

--- a/includes/writer.js
+++ b/includes/writer.js
@@ -5,6 +5,7 @@ const request = require('./request.js');
 const stream = require('stream');
 
 module.exports = function(couchDbUrl, bufferSize, parallelism) {
+  const client = request.client(couchDbUrl, parallelism);
   var buffer = [];
   var written = 0;
   var linenumber = 0;
@@ -18,11 +19,10 @@ module.exports = function(couchDbUrl, bufferSize, parallelism) {
     var r = {
       url: couchDbUrl + '/_bulk_docs',
       method: 'post',
-      json: true,
       body: payload
     };
 
-    request(r, function(err, res, data) {
+    client(r, function(err, res, data) {
       if (err) {
         writer.emit('error', err);
       } else {


### PR DESCRIPTION
## What

Added pool of persistent connections.

## How

Added keep-alive configuration to request defaults and provided a size argument.
* Added the https agent with keep-alive properties.
* Tuned connection pool size in line with parallelism.

Moved other defaults `json: true` and `gzip: true` into the request defaults.

Question for reviewers: does the 30 s idle time seem appropriate?

## Testing

Existing tests pass. No need to test the keep-alive functionality of the request library or Node https agent.

## Issues

Fixes #69 
