### PR TITLE
Examples of using library to write to object store

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ The library exports two main functions:
 1. `backup` - backup from a database to a writable stream.
 2. `restore` - restore from a readable stream to a database.
 
+### Examples
+
+See [the examples folder](./examples) for example scripts showing how to
+use the library.
+
 ### Backup
 
 The `backup` function takes a source database URL, a stream to write to,

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# CouchBackup Examples
+
+This folder contains Node.js scripts which use the `couchbackup` library.
+
+Use `npm install` in this folder to install the script dependencies.
+
+Run a script without arguments to receive help.
+
+## Current examples
+
+### IBM Cloud Object Store S3 API / AWS S3
+
+1. `s3-backup-file.js` -- backup a database to an S3-API compatible store
+    using a intermediate file on disk to store the backup before upload.
+2. `s3-backup-stream.js` -- backup a database to an S3-API compatible store
+    by streaming the backup data directly from CouchDB or Cloudant into
+    an object.

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "couchbackup-examples",
+  "version": "0.0.1",
+  "description": "Examples of using CouchBackup as a library",
+  "dependencies": {
+    "aws-sdk": "^2.39.0",
+    "couchbackup": "^2.0.0",
+    "tmp": "^0.0.31",
+    "verror": "^1.10.0",
+    "yargs": "^7.0.2"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-react": "^7.0.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-config-semistandard": "^11.0.0",
+    "jsdoc": "^3.4.3",
+    "mocha": "^3.2.0",
+    "cloudant": "^1.7.1",
+    "uuid": "^3.0.1"
+  },
+  "scripts": {
+    "test": "eslint --ignore-path .gitignore . && mocha"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}
+
+

--- a/examples/s3-backup-file.js
+++ b/examples/s3-backup-file.js
@@ -1,0 +1,193 @@
+/**
+* Copyright © 2017 IBM Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// Small script which backs up a Cloudant or CouchDB database to an S3
+// bucket, using an intermediary file on disk.
+//
+// The script generates the backup object name by combining together the path
+// part of the database URL and the current time.
+
+'use strict';
+
+const stream = require('stream');
+const fs = require('fs');
+const url = require('url');
+
+const AWS = require('aws-sdk');
+const couchbackup = require('couchbackup');
+const debug = require('debug')('s3-backup');
+const tmp = require('tmp');
+const VError = require('verror').VError;
+
+/*
+  Main function, run from base of file.
+*/
+function main() {
+  var argv = require('yargs')
+    .usage('Usage: $0 [options]')
+    .example('$0 -s https://user:pass@host/db -b <bucket>', 'Backup db to bucket')
+    .options({
+      'source': {alias: 's', nargs: 1, demandOption: true, describe: 'Source database URL'},
+      'bucket': {alias: 'b', nargs: 1, demandOption: true, describe: 'Destination bucket'},
+      'prefix': {alias: 'p', nargs: 1, describe: 'Prefix for backup object key', default: 'couchbackup'},
+      's3url': {nargs: 1, describe: 'S3 endpoint URL'},
+      'awsprofile': {nargs: 1, describe: 'The profile section to use in the ~/.aws/credentials file', default: 'default'}
+    })
+    .help('h').alias('h', 'help')
+    .epilog('Copyright (C) IBM 2017')
+    .argv;
+
+  const sourceUrl = argv.source;
+  const backupBucket = argv.bucket;
+  const backupName = url.parse(sourceUrl).pathname.split('/').filter(function(x) { return x; }).join('-');
+  const backupKeyPrefix = `${argv.prefix}-${backupName}`;
+
+  const backupKey = `${backupKeyPrefix}-${new Date().toISOString()}`;
+  const backupTmpFile = tmp.fileSync();
+
+  const s3Endpoint = argv.s3url;
+  const awsProfile = argv.awsprofile;
+
+  // Creds are from ~/.aws/credentials, environment etc. (see S3 docs).
+  const awsOpts = {
+    signatureVersion: 'v4',
+    credentials: new AWS.SharedIniFileCredentials({profile: awsProfile})
+  };
+  if (typeof s3Endpoint !== 'undefined') {
+    awsOpts.endpoint = new AWS.Endpoint(s3Endpoint);
+  }
+  const s3 = new AWS.S3(awsOpts);
+
+  debug(`Creating a new backup of ${s(sourceUrl)} at ${backupBucket}/${backupKey}...`);
+  bucketAccessible(s3, backupBucket)
+    .then(() => {
+      return createBackupFile(sourceUrl, backupTmpFile.name);
+    })
+    .then(() => {
+      return uploadNewBackup(s3, backupTmpFile.name, backupBucket, backupKey);
+    })
+    .then(() => {
+      debug('Backup successful!');
+      backupTmpFile.removeCallback();
+      debug('done.');
+    })
+    .catch((reason) => {
+      debug(`Error: ${reason}`);
+    });
+}
+
+/**
+ * Return a promise that resolves if the bucket is available and
+ * rejects if not.
+ *
+ * @param {any} s3 S3 client object
+ * @param {any} bucketName Bucket name
+ * @returns Promise
+ */
+function bucketAccessible(s3, bucketName) {
+  return new Promise(function(resolve, reject) {
+    var params = {
+      Bucket: bucketName
+    };
+    s3.headBucket(params, function(err, data) {
+      if (err) {
+        reject(new VError(err, 'S3 bucket not accessible'));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Use couchbackup to create a backup of the specified database to a file path.
+ *
+ * @param {any} sourceUrl Database URL
+ * @param {any} backupTmpFilePath Path to write file
+ * @returns Promise
+ */
+function createBackupFile(sourceUrl, backupTmpFilePath) {
+  return new Promise((resolve, reject) => {
+    couchbackup.backup(
+      sourceUrl,
+      fs.createWriteStream(backupTmpFilePath),
+      (err) => {
+        if (err) {
+          return reject(new VError(err, 'CouchBackup process failed'));
+        }
+        debug('couchbackup to file done; uploading to S3');
+        resolve('creating backup file complete');
+      }
+    );
+  });
+}
+
+/**
+ * Upload a backup file to an S3 bucket.
+ *
+ * @param {any} s3 Object store client
+ * @param {any} backupTmpFilePath Path of backup file to write.
+ * @param {any} bucket Object store bucket name
+ * @param {any} key Object store key name
+ * @returns Promise
+ */
+function uploadNewBackup(s3, backupTmpFilePath, bucket, key) {
+  return new Promise((resolve, reject) => {
+    debug(`Uploading from ${backupTmpFilePath} to ${bucket}/${key}`);
+
+    function uploadFromStream(s3, bucket, key) {
+      const pass = new stream.PassThrough();
+
+      const params = {
+        Bucket: bucket,
+        Key: key,
+        Body: pass
+      };
+      s3.upload(params, function(err, data) {
+        debug('S3 upload done');
+        if (err) {
+          debug(err);
+          reject(new VError(err, 'Upload failed'));
+          return;
+        }
+        debug('Upload succeeded');
+        debug(data);
+        resolve();
+      }).httpUploadProgress = (progress) => {
+        debug(`S3 upload progress: ${progress}`);
+      };
+
+      return pass;
+    }
+
+    const inputStream = fs.createReadStream(backupTmpFilePath);
+    const s3Stream = uploadFromStream(s3, bucket, key);
+    inputStream.pipe(s3Stream);
+  });
+}
+
+/**
+ * Remove creds from a URL, e.g., before logging
+ *
+ * @param {string} url URL to safen
+ */
+function s(url) {
+  var parts = url.parse(url);
+  delete parts.auth;
+  return url.format(parts);
+}
+
+main();

--- a/examples/s3-backup-stream.js
+++ b/examples/s3-backup-stream.js
@@ -1,0 +1,179 @@
+/**
+* Copyright © 2017 IBM Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// Small script which backs up a Cloudant or CouchDB database to an S3
+// bucket via a stream rather than on-disk file.
+//
+// The script generates the backup object name by combining together the path
+// part of the database URL and the current time.
+
+'use strict';
+
+const stream = require('stream');
+const url = require('url');
+
+const AWS = require('aws-sdk');
+const couchbackup = require('couchbackup');
+const debug = require('debug')('s3-backup');
+const VError = require('verror').VError;
+
+/*
+  Main function, run from base of file.
+*/
+function main() {
+  var argv = require('yargs')
+    .usage('Usage: $0 [options]')
+    .example('$0 -s https://user:pass@host/db -b <bucket>', 'Backup db to bucket')
+    .options({
+      'source': {alias: 's', nargs: 1, demandOption: true, describe: 'Source database URL'},
+      'bucket': {alias: 'b', nargs: 1, demandOption: true, describe: 'Destination bucket'},
+      'retain': {alias: 'r', nargs: 1, describe: 'Retain N newest backups', number: true, default: 5},
+      'prefix': {alias: 'p', nargs: 1, describe: 'Prefix for backup object key', default: 'couchbackup'},
+      's3url': {nargs: 1, describe: 'S3 endpoint URL'},
+      'awsprofile': {nargs: 1, describe: 'The profile section to use in the ~/.aws/credentials file', default: 'default'}
+    })
+    .help('h').alias('h', 'help')
+    .epilog('Copyright (C) IBM 2017')
+    .argv;
+
+  const sourceUrl = argv.source;
+  const backupName = url.parse(sourceUrl).pathname.split('/').filter(function(x) { return x; }).join('-');
+  const backupBucket = argv.bucket;
+  const backupKeyPrefix = `${argv.prefix}-${backupName}`;
+  const shallow = argv.shallow;
+
+  const backupKey = `${backupKeyPrefix}-${new Date().toISOString()}`;
+
+  const s3Endpoint = argv.s3url;
+  const awsProfile = argv.awsprofile;
+
+  // Creds are from ~/.aws/credentials, environment etc. (see S3 docs).
+  const awsOpts = {
+    signatureVersion: 'v4',
+    credentials: new AWS.SharedIniFileCredentials({profile: awsProfile})
+  };
+  if (typeof s3Endpoint !== 'undefined') {
+    awsOpts.endpoint = new AWS.Endpoint(s3Endpoint);
+  }
+  const s3 = new AWS.S3(awsOpts);
+
+  debug(`Creating a new backup of ${s(sourceUrl)} at ${backupBucket}/${backupKey}...`);
+  bucketAccessible(s3, backupBucket)
+    .then(() => {
+      return backupToS3(sourceUrl, s3, backupBucket, backupKey, shallow);
+    })
+    .then(() => {
+      debug('done.');
+    })
+    .catch((reason) => {
+      debug(`Error: ${reason}`);
+      process.exit(1);
+    });
+}
+
+/**
+ * Return a promise that resolves if the bucket is available and
+ * rejects if not.
+ *
+ * @param {any} s3 S3 client object
+ * @param {any} bucketName Bucket name
+ * @returns Promise
+ */
+function bucketAccessible(s3, bucketName) {
+  return new Promise(function(resolve, reject) {
+    var params = {
+      Bucket: bucketName
+    };
+    s3.headBucket(params, function(err, data) {
+      if (err) {
+        reject(new VError(err, 'S3 bucket not accessible'));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Backup directly from Cloudant to an object store object via a stream.
+ *
+ * @param {any} sourceUrl URL of database
+ * @param {any} s3Client Object store client
+ * @param {any} s3Bucket Backup destination bucket
+ * @param {any} s3Key Backup destination key name (shouldn't exist)
+ * @param {any} shallow Whether to use the couchbackup `shallow` mode
+ * @returns Promise
+ */
+function backupToS3(sourceUrl, s3Client, s3Bucket, s3Key, shallow) {
+  return new Promise((resolve, reject) => {
+    debug(`Setting up S3 upload to ${s3Bucket}/${s3Key}`);
+
+    // A pass through stream that has couchbackup's output
+    // written to it and it then read by the S3 upload client.
+    // It has a 64MB highwater mark to allow for fairly
+    // uneven network connectivity.
+    const streamToUpload = new stream.PassThrough({highWaterMark: 67108864});
+
+    // Set up S3 upload.
+    const params = {
+      Bucket: s3Bucket,
+      Key: s3Key,
+      Body: streamToUpload
+    };
+    s3Client.upload(params, function(err, data) {
+      debug('Object store upload done');
+      if (err) {
+        debug(err);
+        reject(new VError(err, 'Object store upload failed'));
+        return;
+      }
+      debug('Object store upload succeeded');
+      debug(data);
+      resolve();
+    }).httpUploadProgress = (progress) => {
+      debug(`Object store upload progress: ${progress}`);
+    };
+
+    debug(`Starting streaming data from ${s(sourceUrl)}`);
+    couchbackup.backup(
+      sourceUrl,
+      streamToUpload,
+      (err, obj) => {
+        if (err) {
+          debug(err);
+          reject(new VError(err, 'CouchBackup failed with an error'));
+          return;
+        }
+        debug(`Download from ${s(sourceUrl)} complete.`);
+        streamToUpload.end();  // must call end() to complete upload.
+        // resolve() is called by the upload
+      }
+    );
+  });
+}
+
+/**
+ * Remove creds from a URL, e.g., before logging
+ *
+ * @param {string} url URL to safen
+ */
+function s(url) {
+  var parts = url.parse(url);
+  delete parts.auth;
+  return url.format(parts);
+}
+
+main();


### PR DESCRIPTION
## What

Examples of using library to write to object stores.

## How

The two scripts in this commit show using the library to write to an
object store using two methods:

1. With intermediary temporary file.
2. Streaming directly between CouchDB/Cloudant and the object store.

## Testing

Tested scripts by hand.

## Issues

#73