### PR TITLE
58 add unreliable network tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,65 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-def setupNodeAndTest(version) {
+import groovy.json.JsonSlurper
+
+def getEnv(envName) {
+          // Base environment variables
+          def envVars = [
+            "COUCH_URL_COMPARE=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
+            "DBCOMPARE_NAME=DatabaseCompare",
+            "DBCOMPARE_VERSION=1.0.0",
+            "NVM_DIR=${env.HOME}/.nvm",
+            "TEST_LIMIT=900"
+          ]
+
+          // Add test suite specific environment variables
+          switch(envName) {
+            case 'test-default':
+              envVars.add("COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+              break
+            case 'toxy-default':
+              envVars.add("COUCH_URL=http://localhost:3000") // proxy
+              envVars.add("TEST_PROXY_BACKEND=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com")
+              break
+            default:
+              error("Unknown test suite environment ${envName}")
+          }
+
+          return envVars
+}
+
+def setupNodeAndTest(version, testSuite='test', envName='default') {
     node {
-        // Install nvm
+        // Install NVM
         sh 'wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash'
         // Unstash the built content
         unstash name: 'built'
-        // run tests using creds
+
+        // Run tests using creds
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'],
                          [$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactory', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PW']]) {
-            withEnv(["COUCH_URL=https://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_USER}.cloudant.com",
-              "NVM_DIR=${env.HOME}/.nvm",
-              "DBCOMPARE_VERSION=1.0.0",
-              "DBCOMPARE_NAME=DatabaseCompare",
-              "TEST_LIMIT=900"]) {
-                try {
-                    // Run in a single sh to preserve nvm Node version
-                    // Load NVM
-                    // Install/use required Node.js version
-                    // Install mocha-junit-reporter so that we can get junit style output
-                    // Run the unit tests
-                    // Test the backup
-                    sh """
-                        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                        nvm install ${version}
-                        nvm use ${version}
-                        npm install mocha-junit-reporter --save-dev
-                        ./node_modules/mocha/bin/mocha test --reporter mocha-junit-reporter
-                        cd citest
-                        # setup DatabaseCompare
-                        curl -O -u ${env.ARTIFACTORY_USER}:${env.ARTIFACTORY_PW} https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
-                        unzip ${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
-                        # run backup and restore tests
-                        ../node_modules/mocha/bin/mocha test --reporter mocha-junit-reporter
-                    """
-                } finally {
-                    junit '**/test-results.xml'
-                }
+          withEnv(getEnv("${testSuite}-${envName}")) {
+            try {
+              // Actions:
+              //  - Load NVM
+              //  - Install/use required Node.js version
+              //  - Install mocha-junit-reporter so that we can get junit style output
+              //  - Run unit tests
+              //  - Fetch database compare tool for CI tests
+              //  - Run test suite
+              sh """
+                [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                nvm install ${version}
+                nvm use ${version}
+                npm install mocha-junit-reporter --save-dev
+                ./node_modules/mocha/bin/mocha test --reporter mocha-junit-reporter --reporter-options mochaFile=./test/unit-test-results.xml
+                cd citest
+                curl -O -u ${env.ARTIFACTORY_USER}:${env.ARTIFACTORY_PW} https://na.artifactory.swg-devops.com/artifactory/cloudant-sdks-maven-local/com/ibm/cloudant/${env.DBCOMPARE_NAME}/${env.DBCOMPARE_VERSION}/${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+                unzip ${env.DBCOMPARE_NAME}-${env.DBCOMPARE_VERSION}.zip
+                ../node_modules/mocha/bin/mocha ${testSuite} --reporter mocha-junit-reporter --reporter-options mochaFile=./ci-${testSuite}-results.xml
+              """
+            } finally {
+              junit '**/*test-results.xml'
             }
+          }
         }
     }
 }
+
+@NonCPS
+def isReleaseVersion(packageText) {
+  def info = new JsonSlurper().parseText(packageText)
+  !info['version'].toUpperCase(Locale.ENGLISH).contains('SNAPSHOT')
+}
+
+def releaseVersion
 
 stage('Build') {
     // Checkout, build
     node {
         checkout scm
+        releaseVersion = isReleaseVersion(readFile('package.json'))
         sh 'npm install'
         stash name: 'built'
     }
 }
 
 stage('QA') {
-    // Use the oldest supported version of Node
-    def axes = [ Node4x : {setupNodeAndTest('lts/argon')}] //4.x LTS
-    // Add some other versions (possibly just do this for master later)
-    axes.putAll(
-            Node6x : { setupNodeAndTest('lts/boron') }, // 6.x LTS
-            Node : { setupNodeAndTest('node') } // Current
-            )
-    // Run the required axes in parallel
-    parallel(axes)
+  def axes = [
+    Node4x:{ setupNodeAndTest('lts/argon') }, //4.x LTS
+    Node6x:{ setupNodeAndTest('lts/boron') }, // 6.x LTS
+    Node:{ setupNodeAndTest('node') } // Current
+  ]
+  // Add unreliable network tests for release builds
+  if (releaseVersion) {
+    axes.Network = { setupNodeAndTest('node', 'toxy') }
+  }
+  // Run the required axes in parallel
+  parallel(axes)
 }

--- a/citest/citestutils.js
+++ b/citest/citestutils.js
@@ -403,7 +403,7 @@ function testBackupAbortResumeRestore(params, srcDb, backupFile, targetDb, callb
 
 function dbCompare(db1Name, db2Name, callback) {
   const comparison = spawn(`./${process.env.DBCOMPARE_NAME}-${process.env.DBCOMPARE_VERSION}/bin/${process.env.DBCOMPARE_NAME}`,
-    [process.env.COUCH_URL, db1Name, process.env.COUCH_URL, db2Name], {'stdio': 'inherit'});
+    [process.env.COUCH_URL_COMPARE, db1Name, process.env.COUCH_URL_COMPARE, db2Name], {'stdio': 'inherit'});
   comparison.on('exit', function(code) {
     try {
       assert.equal(code, 0, `The database comparison should succeed, got exit code ${code}`);

--- a/citest/toxy.js
+++ b/citest/toxy.js
@@ -1,0 +1,128 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global after before describe */
+'use strict';
+
+const url = require('url');
+const toxy = require('toxy');
+
+const tpoisons = toxy.poisons;
+const trules = toxy.rules;
+
+function setupProxy(poison) {
+  var proxy = toxy({
+    auth: url.parse(process.env.TEST_PROXY_BACKEND).auth,
+    changeOrigin: true
+  });
+
+  switch (poison) {
+    case 'normal':
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .all('/*');
+      break;
+    case 'abort':
+      // https://github.com/h2non/toxy#abort-connection
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.abort())
+        .withRule(trules.timeThreshold({ duration: 1000, threshold: 5000 }))
+        .all('/*');
+      break;
+    case 'bandwidth-limit':
+      // https://github.com/h2non/toxy#bandwidth
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.bandwidth({ bps: 2048 }))
+        .all('/*');
+      break;
+    case 'latency':
+      // https://github.com/h2non/toxy#latency
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.latency({ max: 20000, min: 100 }))
+        .withRule(trules.probability(50))
+        .all('/*');
+      break;
+    case 'rate-limit':
+      // https://github.com/h2non/toxy#rate-limit
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.rateLimit({ limit: 5, threshold: 1000 }))
+        .withRule(trules.probability(90))
+        .all('/*');
+      break;
+    case 'slow-read':
+      // https://github.com/h2non/toxy#slow-read
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.slowRead({ bps: 1024, threshold: 100 }))
+        .withRule(trules.probability(90))
+        .all('/*');
+      break;
+    case 'unexpected-errors':
+      // https://github.com/h2non/toxy#inject-response
+      proxy
+        .forward(process.env.TEST_PROXY_BACKEND)
+        .poison(tpoisons.inject({
+          code: 503,
+          body: '{"error": "toxy injected error"}',
+          headers: { 'Content-Type': 'application/json' }
+        }))
+        .withRule(trules.probability(90))
+        .all('/*');
+      break;
+    default:
+      throw Error('Unknown toxy poison ' + poison);
+  }
+
+  return proxy;
+}
+
+const poisons = [
+  'normal'
+  //
+  //  FIXME: Fix unreliable network tests
+  //         [https://github.com/cloudant/couchbackup/issues/79]
+  //
+  //  'abort',
+  //  'bandwidth-limit',
+  //  'latency',
+  //  'rate-limit',
+  //  'slow-read',
+  //  'unexpected-errors'
+];
+
+poisons.forEach(function(poison) {
+  describe('unreliable network tests (using toxy poison ' + poison + ')', function() {
+    var proxy;
+
+    before('start toxy server', function() {
+      proxy = setupProxy(poison);
+      console.log('Using toxy poison ' + poison);
+
+      // For these tests COUCH_URL points to the toxy proxy on localhost whereas
+      // TEST_PROXY_BACKEND is the real CouchDb instance.
+
+      proxy.listen(url.parse(process.env.COUCH_URL).port);
+    });
+
+    after('stop toxy server', function() {
+      proxy.close();
+    });
+
+    require('./test.js');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-header": "^1.0.0",
     "jsdoc": "^3.4.3",
     "mocha": "^3.2.0",
+    "toxy": "^0.3.12",
     "cloudant": "^1.7.1",
     "uuid": "^3.0.1",
     "tail": "^1.2.1"


### PR DESCRIPTION
## What
Add unreliable network tests.

## How
Run existing CI tests via toxy proxy in order to validate a successful backup/restore over an unreliable connection.

_Note:_ 
This commit isn't setting a toxy poison, it is merely acting as a normal proxy. Issue #79 has been opened to further expand on these tests.

These toxy tests only run on release builds. Note that commit 7c9ddc50fa13f17b364c8e25afdb1c6c051d11f1 is therefore required for these tests to run. However, it will be removed before merging to master.

## Testing
Additional tests added.

## Issues
Fixes #58.
