### PR TITLE
6 abort resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "jsdoc": "^3.4.3",
     "mocha": "^3.2.0",
     "cloudant": "^1.7.1",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "tail": "^1.2.1"
   },
   "scripts": {
     "test": "eslint --ignore-path .gitignore . && mocha"


### PR DESCRIPTION
## What

Added abort/resume tests.

## How

* Removed unused test export

* Exposed functions for backup and resume with file.
* Added options parsing for log, resume, output.
* Fixed some assertion messages to be more useful.
* Added abort functionality to terminate backups.
* Included functionality for API cases when API abort is supported.

See below for tests added.

## Testing

Added new tests for abort/resume:

* Added test for log file existence.
* Added abort/resume tests for CLI cases:
    * Added abort/resume test using stdio.
    * Added abort/resume test using --output option.

## Issues

Fixes #6 
