### PR TITLE
Issue83

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,3 +23,4 @@
 - [FIXED] An issue where a restore of a resumed backup might not complete due to
   incomplete JSON entries in the backup file.
 - [FIXED] An issue where an empty batch could be written to the backup file.
+- [FIXED] An issue where the restore-time buffer size was ignored.


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [x] You have added tests for any code changes [CONTRIBUTING.md](https://github.com/cloudant/couchbackup/blob/master/CONTRIBUTING.md#adding-tests)
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/couchbackup/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

The restore process was passed the `bufferSize` from environment, parameter or command-line option but used it in an erroneous way. This PR fixes the how `bufferSize` is used during restoration.

## How

During restoration from a backup file, each line of the file is streamed into the app in turn. Each line will contain `bufferSize` documents (500 by default). The restore process has its own `bufferSize` which could be different from the backup-time value. This means that each line of data must be reorganised into chunks of `bufferSize` documents before being sent to CouchDB - this allows extra control of the restore process, and modifies the code to perform as intended.

## Testing

How to test your changes work, not required for documentation changes.

    couchbackup --db x --buffer-size 500 > x.txt
    cat x.txt | couchrestore --db y --buffer-size 49

## Issues

issue #83 
