### PR TITLE
Fixed finished event for stdout

### DIFF
--- a/citest/test.js
+++ b/citest/test.js
@@ -229,3 +229,47 @@ describe('Resume tests', function() {
     u.testBackupAbortResumeRestore(p, 'backup10m', actualBackup, restoreDb, done);
   });
 });
+
+describe('Event tests', function() {
+  it('should get a finished event when using stdout', function(done) {
+    u.timeoutFilter(this, 40);
+    // Use the API so we can get events
+    const params = {useApi: true};
+    const backup = u.testBackup(params, 'animaldb', process.stdout, function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+    backup.on('finished', function() {
+      try {
+        // Test will time out if the finished event is not emitted
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+  it('should get a finished event when using file output', function(done) {
+    u.timeoutFilter(this, 40);
+    // Use the API so we can get events
+    const params = {useApi: true};
+    const actualBackup = `./${this.fileName}`;
+    // Create a file and backup to it
+    const output = fs.createWriteStream(actualBackup);
+    output.on('open', function() {
+      const backup = u.testBackup(params, 'animaldb', output, function(err) {
+        if (err) {
+          done(err);
+        }
+      });
+      backup.on('finished', function() {
+        try {
+          // Test will time out if the finished event is not emitted
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

Fixed finished event when using `stdout` for backup.

## How

Since `end` cannot be called for `stdout` in those cases just make a final empty write to get a callback after the flush.
Extracted out an `emitFinished` function to use in both cases.
This is covered by the existing `CHANGES.md` entry for:
>- [FIXED] An issue where the process could exit before the backup content was
  completely flushed to the destination stream.

## Testing

Added new tests to check the finished event is emitted in both cases.

## Issues

Fixes #70 
