### PR TITLE
Fixed test regex for new output

### DIFF
--- a/citest/citestutils.js
+++ b/citest/citestutils.js
@@ -335,15 +335,15 @@ function assertResumedBackup(params, resumedBackup, restoreCallback) {
   // Validate that the resume backup didn't need to write all the docs
   if (params.useApi) {
     resumedBackup.once('finished', function(summary) {
-      assertWrittenFewerThan(summary, params.exclusiveMaxExpected, restoreCallback);
+      assertWrittenFewerThan(summary.total, params.exclusiveMaxExpected, restoreCallback);
     });
   } else {
     // For the CLI case we need to see the output because we don't have
     // the finished event.
     const listener = function(data) {
-      let matches = data.toString().match(/.*Backup complete - written ({"total":\d+}).*/);
+      let matches = data.toString().match(/.*finished { total: (\d+) }.*/);
       if (matches !== null) {
-        assertWrittenFewerThan(JSON.parse(matches[1]), params.exclusiveMaxExpected, restoreCallback);
+        assertWrittenFewerThan(matches[1], params.exclusiveMaxExpected, restoreCallback);
         resumedBackup.stderr.removeListener('data', listener);
       }
     };
@@ -478,9 +478,9 @@ function assertGzipFile(path, callback) {
   }
 }
 
-function assertWrittenFewerThan(summary, number, callback) {
+function assertWrittenFewerThan(total, number, callback) {
   try {
-    assert(summary.total < number && summary.total > 0, `Saw ${summary.total} but expected between 1 and ${number - 1} documents for the resumed backup.`);
+    assert(total < number && total > 0, `Saw ${total} but expected between 1 and ${number - 1} documents for the resumed backup.`);
     callback();
   } catch (err) {
     callback(err);


### PR DESCRIPTION
## What

Fixed the test failures caused by output changes introduced in #85 

## How

The output messages were changed in #85 and this caused the CLI abort tests to fail. Those tests listen on `stderr` to identify the number of documents backed up (in order to assert that a resumed backup was not a complete backup). This is necessary since the `finished` event is not otherwise exposed to a CLI caller.

The reasons this was not caught before the merge to master are twofold:
1. #85 was green when it was reviewed since it branched before the delivery of the abort/resume tests
1. After rebasing the branch appears to have been merged before the Jenkins build completed, likely due to the lag between polling of the repository for changes before the triggering of the Jenkins CI tests.

The problem is fixed by updating the regex for the new output and since that output is no longer JSON parseable, extracting the number of documents as part of the regex instead of the whole summary object.

## Testing

No new tests, this is a fix to test code and all tests are passing.

## Issues

Fixes #89 
