### PR TITLE
Add argument validation

### DIFF
--- a/includes/error.js
+++ b/includes/error.js
@@ -24,6 +24,7 @@ module.exports = {
     if (err) {
       process.on('uncaughtException', function(err) {
         var exitCode = {
+          'InvalidOption': 2,
           'RestoreDatabaseNotFound': 10,
           'NoLogFileName': 20,
           'LogDoesNotExist': 21

--- a/includes/parser.js
+++ b/includes/parser.js
@@ -41,7 +41,7 @@ function parseBackupArgs() {
             path.normalize, defaults.log)
     .option('-m, --mode <mode>',
             cliutils.getUsage('"shallow" if only a superficial backup is done (ignoring conflicts and revision tokens), else "full" for complete backup', defaults.mode),
-            defaults.mode)
+            (mode) => { return mode.toLowerCase(); }, defaults.mode)
     .option('-o, --output <file>',
             cliutils.getUsage('file name to store the backup data', 'stdout'),
             path.normalize, defaults.output)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "toxy": "^0.3.12",
     "cloudant": "^1.7.1",
     "uuid": "^3.0.1",
-    "tail": "^1.2.1"
+    "tail": "^1.2.1",
+    "rewire": "^2.4.20"
   },
   "scripts": {
     "test": "eslint --ignore-path .gitignore . && mocha"

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,84 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+'use strict';
+
+const assert = require('assert');
+const rewire = require('rewire');
+const app = rewire('../app.js');
+
+const validateArgs = app.__get__('validateArgs');
+
+describe('Validate arguments', function() {
+  const goodUrl = 'http://localhost:5984/db';
+
+  it('returns error for invalid URL type', function() {
+    validateArgs(true, {}, (err, data) => assert.equal(err.message, 'ERROR: Invalid URL, must be type string'));
+  });
+  it('returns no error for valid URL type', function() {
+    validateArgs(goodUrl, {}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid buffer size type', function() {
+    validateArgs(goodUrl, {bufferSize: '123'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for zero buffer size', function() {
+    validateArgs(goodUrl, {bufferSize: 0}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for float buffer size', function() {
+    validateArgs(goodUrl, {bufferSize: 1.23}, (err, data) => assert.equal(err.message, 'ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns no error for valid buffer size type', function() {
+    validateArgs(goodUrl, {bufferSize: 123}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid log type', function() {
+    validateArgs(goodUrl, {log: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid log option, must be type string'));
+  });
+  it('returns no error for valid log type', function() {
+    validateArgs(goodUrl, {log: 'log.txt'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid mode type', function() {
+    validateArgs(goodUrl, {mode: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid mode option, must be either "full" or "shallow"'));
+  });
+  it('returns error for invalid mode string', function() {
+    validateArgs(goodUrl, {mode: 'foobar'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid mode option, must be either "full" or "shallow"'));
+  });
+  it('returns no error for valid mode type', function() {
+    validateArgs(goodUrl, {mode: 'full'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid output type', function() {
+    validateArgs(goodUrl, {output: true}, (err, data) => assert.equal(err.message, 'ERROR: Invalid output option, must be type string'));
+  });
+  it('returns no error for valid output type', function() {
+    validateArgs(goodUrl, {output: 'output.txt'}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid parallelism type', function() {
+    validateArgs(goodUrl, {parallelism: '123'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for zero parallelism', function() {
+    validateArgs(goodUrl, {parallelism: 0}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns error for float parallelism', function() {
+    validateArgs(goodUrl, {parallelism: 1.23}, (err, data) => assert.equal(err.message, 'ERROR: Invalid parallelism option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));
+  });
+  it('returns no error for valid parallelism type', function() {
+    validateArgs(goodUrl, {parallelism: 123}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+  it('returns error for invalid resume type', function() {
+    validateArgs(goodUrl, {resume: 'true'}, (err, data) => assert.equal(err.message, 'ERROR: Invalid resume option, must be type boolean'));
+  });
+  it('returns no error for valid resume type', function() {
+    validateArgs(goodUrl, {resume: true}, (err, data) => assert.fail('Unexpected error: ' + err.message));
+  });
+});


### PR DESCRIPTION
## What
Add argument validation for API/CLI.

## How
Validate arguments in `app.js`, ensuring the following:

 - bufferSize > 0 && is type numb
 - log is type str
 - mode is type str
 - output is type str
 - parallelism > 0 && is type numb
 - resume is type bool
 - url is type str

_Example CLI failure:_
```
$ couchbackup -p 0
================================================================================
Performing backup on https://127.0.0.1:3000/test using configuration:
{
  "bufferSize": 500,
  "log": "/var/folders/5p/11lmsvwn5l91cn7ysrs4nm1r0000gn/T/tmp-80910AJkzkqh7FY5.tmp",
  "mode": "full",
  "parallelism": 0
}
================================================================================
ERROR: Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]
$ echo $?
2
```

## Testing
Added additional unit tests.

## Issues
Fixes #88 .
