### PR TITLE
Ensure body 'rows' key exists before performing shallow backup

### DIFF
--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -40,8 +40,8 @@ module.exports = function(dbUrl, blocksize, parallelism, log, resume) {
       qs: opts
     };
     client(r, function(err, res, data) {
-      if (err) {
-        ee.emit('error', err);
+      if (err || !data.rows) {
+        ee.emit('error', err || data);
         return callback(null, null);
       }
 


### PR DESCRIPTION
## What
Ensure body 'rows' key exists before performing shallow backup.
```
$ couchbackup -m shallow
================================================================================
Performing backup on http://localhost:5984/test using configuration:
{
  "bufferSize": 500,
  "log": "/var/folders/5p/11lmsvwn5l91cn7ysrs4nm1r0000gn/T/tmp-87104B0aTRZFpGRE9.tmp",
  "mode": "shallow",
  "parallelism": 5
}
================================================================================
  couchbackup:backup ERROR { error: 'not_found', reason: 'Database does not exist.' } +0ms
  couchbackup:backup finished { total: 0 } +3ms
```

## Issues
Fixes #93.
