### PR TITLE
Prepare 2.9.10 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
-# Unreleased
+# 2.9.10 (2023-06-09)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.2`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.8` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to minimum version `1.4.0` to match version provided from `ibm-cloud-sdk-core`.
 - [NOTE] Repository moved from https://github.com/cloudant/couchbackup to https://github.com/IBM/couchbackup.
+- [NOTE] Updated Node.js version requirement statement for LTS 16 and 18.
 
 # 2.9.9 (2023-05-03)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.1`.
@@ -156,7 +160,7 @@
 
 # 2.0.0 (2017-07-04)
 
-- [NEW] Moved to https://github.com/IBM/couchbackup repository.
+- [NEW] Moved to https://github.com/cloudant/couchbackup repository.
 - [NEW] Validate backup/restore options.
 - [NEW] Add User-Agent header to all requests.
 - [NEW] Added unique CLI exit codes for known error conditions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.10-SNAPSHOT",
+  "version": "2.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.10-SNAPSHOT",
+      "version": "2.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.10-SNAPSHOT",
+  "version": "2.9.10",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.10 release

# Changes

```
# 2.9.10 (2023-06-09)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.2`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.8` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to minimum version `1.4.0` to match version provided from `ibm-cloud-sdk-core`.
- [NOTE] Repository moved from https://github.com/cloudant/couchbackup to https://github.com/IBM/couchbackup.
- [NOTE] Updated Node.js version requirement statement for LTS 16 and 18.
```
