### PR TITLE
Prepare 2.9.11 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.9.11 (2023-06-29)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.4`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.9` to match version provided from `@ibm-cloud/cloudant`.
+
 # 2.9.10 (2023-06-09)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.2`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.8` to match version provided from `@ibm-cloud/cloudant`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.11-SNAPSHOT",
+  "version": "2.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.11-SNAPSHOT",
+      "version": "2.9.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       },
       "peerDependencies": {
         "axios": "^1.4.0",
-        "ibm-cloud-sdk-core": "^4.0.8",
+        "ibm-cloud-sdk-core": "^4.0.9",
         "retry-axios": "^2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.11-SNAPSHOT",
+  "version": "2.9.11",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "0.2.1"
   },
   "peerDependencies": {
-    "ibm-cloud-sdk-core": "^4.0.8",
+    "ibm-cloud-sdk-core": "^4.0.9",
     "retry-axios": "^2.6.0",
     "axios": "^1.4.0"
   },


### PR DESCRIPTION
# Proposed 2.9.11 release

# Changes
<!-- Paste the changes information here -->
# 2.9.11 (2023-06-29)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.4`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.9` to match version provided from `@ibm-cloud/cloudant`.
