### PR TITLE
Prepare 2.9.12 release

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-22T14:06:40Z",
+  "generated_at": "2023-09-01T15:11:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -224,7 +224,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.60.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.9.12 (2023-09-04)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.6.0`.
+
 # 2.9.11 (2023-06-29)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.5.4`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.0.9` to match version provided from `@ibm-cloud/cloudant`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.12-SNAPSHOT",
+  "version": "2.9.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.12-SNAPSHOT",
+      "version": "2.9.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.12-SNAPSHOT",
+  "version": "2.9.12",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.12 release

# Changes

# 2.9.12 (2023-09-04)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.6.0`.
