### PR TITLE
build: remove Node 16 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ def agentYaml() {
     |        limits:
     |          memory: "4Gi"
     |          cpu: "4"
-    ${nodeYaml(16)}
+    ${nodeYaml(18)}
     ${nodeYaml(20)}
     |restartPolicy: Never""".stripMargin('|')
 }
@@ -202,16 +202,6 @@ pipeline {
           steps {
             script{
               runTest('18', '', 'toxytests/toxy')
-            }
-          }
-        }
-        // Stages that run for other version node containers in the pod
-        stage('Node 16x') {
-          steps {
-            container('node16') {
-              script{
-                runTest('16')
-              }
             }
           }
         }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install -g @cloudant/couchbackup
 ```
 
 ### Requirements
-* Node.js LTS version 16 or 18.
+* Node.js LTS version 18.
 * The minimum required CouchDB version is 2.0.0.
 
 ### Snapshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "uuid": "9.0.0"
       },
       "engines": {
-        "node": "^16 || ^18"
+        "node": "^18"
       },
       "peerDependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16 || ^18"
+    "node": "^18"
   },
   "dependencies": {
     "@ibm-cloud/cloudant": "0.6.0",


### PR DESCRIPTION
## Checklist
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Node 16 is EOL on Sept 11 2023. We should remove support.

## Approach

- Remove Node 16 from package.json engines
- Remove from README
- Remove Node 16 from Jenkins matrix

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
