### PR TITLE
build(peer-deps): update ibm-cloud-sdk-core to 4.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       },
       "peerDependencies": {
         "axios": "^1.4.0",
-        "ibm-cloud-sdk-core": "^4.0.9",
+        "ibm-cloud-sdk-core": "^4.1.2",
         "retry-axios": "^2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "0.2.1"
   },
   "peerDependencies": {
-    "ibm-cloud-sdk-core": "^4.0.9",
+    "ibm-cloud-sdk-core": "^4.1.2",
     "retry-axios": "^2.6.0",
     "axios": "^1.4.0"
   },


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - build only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - build only
- [x] Completed the PR template below:

## Description

Update peer dependency for `ibm-cloud-sdk-core` to `4.1.2`.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Using `ibm-cloud-sdk-core` `4.1.1` causes failures.

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

Tests fail - see https://github.com/IBM/couchbackup/pull/616 that included that core `4.1.1` with `@ibm-cloud/cloudant` `0.7.0` .

## Approach

Raise the minimum peer dependency level to avoid using the broken version.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
