### PR TITLE
Prepare 2.9.13 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.9.13 (2023-09-28)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.1`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.1.2` to match version provided from `@ibm-cloud/cloudant`.
+- [NOTE] Updated minimum supported engine to Node.js 18 `hydrogen` LTS.
+
 # 2.9.12 (2023-09-04)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.6.0`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.13-SNAPSHOT",
+  "version": "2.9.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.13-SNAPSHOT",
+      "version": "2.9.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.13-SNAPSHOT",
+  "version": "2.9.13",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.13 release

# Changes

# 2.9.13 (2023-09-28)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.1`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.1.2` to match version provided from `@ibm-cloud/cloudant`.
- [NOTE] Updated minimum supported engine to Node.js 18 `hydrogen` LTS.
