### PR TITLE
Modernize test backup/restore - cleanups

### DIFF
--- a/test/ci_event.js
+++ b/test/ci_event.js
@@ -15,49 +15,22 @@
 /* global describe it */
 'use strict';
 
-const fs = require('fs');
 const u = require('./citestutils.js');
 
 describe('Event tests', function() {
-  it('should get a finished event when using stdout', function(done) {
+  it('should get a finished event when using stdout', async function() {
     u.setTimeout(this, 40);
     // Use the API so we can get events, pass eventEmitter so we get the emitter back
-    const params = { useApi: true, eventEmitter: true };
-    const backup = u.testBackup(params, 'animaldb', process.stdout, function(err) {
-      if (err) {
-        done(err);
-      }
-    });
-    backup.on('finished', function() {
-      try {
-        // Test will time out if the finished event is not emitted
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
+    const params = { useApi: true, useStdOut: true };
+    // All API backups now set an event listener for finished and it is part of the backup
+    // promise, so if the backup passes the finished event fired.
+    return u.testBackup(params, 'animaldb', process.stdout);
   });
-  it('should get a finished event when using file output', function(done) {
+  it('should get a finished event when using file output', async function() {
     u.setTimeout(this, 40);
     // Use the API so we can get events, pass eventEmitter so we get the emitter back
-    const params = { useApi: true, eventEmitter: true };
+    const params = { useApi: true };
     const actualBackup = `./${this.fileName}`;
-    // Create a file and backup to it
-    const output = fs.createWriteStream(actualBackup);
-    output.on('open', function() {
-      const backup = u.testBackup(params, 'animaldb', output, function(err) {
-        if (err) {
-          done(err);
-        }
-      });
-      backup.on('finished', function() {
-        try {
-          // Test will time out if the finished event is not emitted
-          done();
-        } catch (err) {
-          done(err);
-        }
-      });
-    });
+    return u.testBackupToFile(params, 'animaldb', actualBackup, () => {});
   });
 });

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -355,22 +355,11 @@ function testRestoreFromFile(params, backupFile, targetDb, callback) {
 function testDirectBackupAndRestore(params, srcDb, targetDb, callback) {
   // Allow a 64 MB highWaterMark for the passthrough during testing
   const passthrough = new PassThrough({ highWaterMark: 67108864 });
-  testBackupAndRestore(params, srcDb, passthrough, passthrough, targetDb, callback);
-}
-
-function testBackupAndRestore(params, srcDb, backupStream, restoreStream, targetDb, callback) {
-  testBackup(params, srcDb, backupStream, function(err) {
-    if (err) {
-      callback(err);
-    }
-  });
-  testRestore(params, restoreStream, targetDb, function(err) {
-    if (err) {
-      callback(err);
-    } else {
-      dbCompare(srcDb, targetDb, callback);
-    }
-  });
+  const backup = testBackup(params, srcDb, passthrough, () => {});
+  const restore = testRestore(params, passthrough, targetDb, () => {});
+  Promise.all([backup, restore]).then(() => {
+    dbCompare(srcDb, targetDb, callback);
+  }).catch((err) => callback(err));
 }
 
 function testBackupAbortResumeRestore(params, srcDb, backupFile, targetDb, callback) {

--- a/test/test_process.js
+++ b/test/test_process.js
@@ -48,6 +48,11 @@ class TestProcess {
         logProcess(`Will reject process promise for ${cmd} with ${e}`);
         return Promise.reject(e);
       }
+    }).finally(() => {
+      // If we finished the process but the writable side of the duplex was not ended, end it.
+      if (!this.stream.writableEnded) {
+        this.stream.end();
+      }
     });
     // Make sure we get error output on the main process error log too
     this.childProcess.stderr.pipe(process.stderr);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

Cleanups of the last failing tests after #621 and #623.

Part of i272.

## Approach

* Add backup promises for the callback and finished events and "all" them.
* Special cased the stdout test so it isn't part of a pipeline, otherwise it gets closed out and mocha can't write anything else to it.
* Cleaned up the event tests with promises.

Note should merge after #623 with just 7cd4c48139191627e27b02ec1ff91781ccc75f62 and bd26397f27632575336dd9643b3bc670a7f27624

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests as outlined above.
- Introduced a new paramter for using stdout.

## Monitoring and Logging

- Added some extra logging in clitestutils.

