### PR TITLE
ci: use node18 container

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-01T15:11:34Z",
+  "generated_at": "2023-10-17T15:26:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "570e6c6e82c51d48f263e940a2b5281375733d54",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 129,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes  - test/build only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test/build only
- [x] Completed the PR template below:

## Description

Prepare the for default agent to move to Node 20 by explicitly asking for Node 18.

## Approach

Add `container('node18')` wrapping for most stages.
Remove `container('node20')` for the (currently unused) Node 20 stage.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
