### PR TITLE
test: avoid interpolation with node encoder

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-17T15:26:58Z",
+  "generated_at": "2023-10-19T12:26:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,16 +77,6 @@
     }
   ],
   "results": {
-    "Jenkinsfile": [
-      {
-        "hashed_secret": "570e6c6e82c51d48f263e940a2b5281375733d54",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 129,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "README.md": [
       {
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test/build change
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test/build change
- [x] Completed the PR template below:

## Description

Avoid groovy interpolation by using Node's encodeURIComponent in a shell evaluation.

## Approach

Use a sub-shell to rn `node -e` of a js statement that calls `encodeURIComponent` of the environment variable and outputs the encoded value when evaluating the `COUCH_BACKEND_URL`  env var.

## Schema & API Changes

- "No change"

## Security and Privacy

- Avoids Jenkins needing to do a groovy string interpolation of credentials.

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
