### PR TITLE
fix: wrap ERR_INVALID_URL in InvalidOption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [FIXED] Corrected error handling for invalid URLs.
+
 # 2.9.13 (2023-09-28)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.1`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.1.2` to match version provided from `@ibm-cloud/cloudant`.

--- a/app.js
+++ b/app.js
@@ -101,10 +101,6 @@ function validateArgs(url, opts, cb) {
       cb(new error.BackupError('InvalidOption', 'Invalid URL protocol.'));
       return;
     }
-    if (!urlObject.host) {
-      cb(new error.BackupError('InvalidOption', 'Invalid URL host.'));
-      return;
-    }
     if (!urlObject.pathname || urlObject.pathname === '/') {
       cb(new error.BackupError('InvalidOption', 'Invalid URL, missing path element (no database).'));
       return;
@@ -114,7 +110,7 @@ function validateArgs(url, opts, cb) {
       return;
     }
   } catch (err) {
-    cb(err);
+    cb(error.wrapPossibleInvalidUrlError(err));
     return;
   }
 

--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -24,33 +24,37 @@ const restoreBatchDebug = debug('couchbackup:restore:batch');
 
 restoreDebug.enabled = true;
 
-const program = parser.parseRestoreArgs();
-const databaseUrl = cliutils.databaseUrl(program.url, program.db);
-const opts = {
-  bufferSize: program.bufferSize,
-  parallelism: program.parallelism,
-  requestTimeout: program.requestTimeout,
-  iamApiKey: program.iamApiKey,
-  iamTokenUrl: program.iamTokenUrl
-};
+try {
+  const program = parser.parseRestoreArgs();
+  const databaseUrl = cliutils.databaseUrl(program.url, program.db);
+  const opts = {
+    bufferSize: program.bufferSize,
+    parallelism: program.parallelism,
+    requestTimeout: program.requestTimeout,
+    iamApiKey: program.iamApiKey,
+    iamTokenUrl: program.iamTokenUrl
+  };
 
-// log configuration to console
-console.error('='.repeat(80));
-console.error('Performing restore on ' + databaseUrl.replace(/\/\/.+@/g, '//****:****@') + ' using configuration:');
-console.error(JSON.stringify(opts, null, 2).replace(/"iamApiKey": "[^"]+"/, '"iamApiKey": "****"'));
-console.error('='.repeat(80));
+  // log configuration to console
+  console.error('='.repeat(80));
+  console.error('Performing restore on ' + databaseUrl.replace(/\/\/.+@/g, '//****:****@') + ' using configuration:');
+  console.error(JSON.stringify(opts, null, 2).replace(/"iamApiKey": "[^"]+"/, '"iamApiKey": "****"'));
+  console.error('='.repeat(80));
 
-restoreBatchDebug.enabled = !program.quiet;
+  restoreBatchDebug.enabled = !program.quiet;
 
-return couchbackup.restore(
-  process.stdin, // restore from stdin
-  databaseUrl,
-  opts,
-  error.terminationCallback
-).on('restored', function(obj) {
-  restoreBatchDebug('restored', obj.total);
-}).on('error', function(e) {
-  restoreDebug('ERROR', e);
-}).on('finished', function(obj) {
-  restoreDebug('finished', obj);
-});
+  return couchbackup.restore(
+    process.stdin, // restore from stdin
+    databaseUrl,
+    opts,
+    error.terminationCallback
+  ).on('restored', function(obj) {
+    restoreBatchDebug('restored', obj.total);
+  }).on('error', function(e) {
+    restoreDebug('ERROR', e);
+  }).on('finished', function(obj) {
+    restoreDebug('finished', obj);
+  });
+} catch (err) {
+  error.terminationCallback(err);
+}

--- a/includes/cliutils.js
+++ b/includes/cliutils.js
@@ -20,6 +20,7 @@
  */
 
 const url = require('url');
+const error = require('./error.js');
 
 module.exports = {
 
@@ -37,7 +38,11 @@ module.exports = {
     if (!root.endsWith('/')) {
       root = root + '/';
     }
-    return new url.URL(encodeURIComponent(databaseName), root).toString();
+    try {
+      return new url.URL(encodeURIComponent(databaseName), root).toString();
+    } catch (err) {
+      throw error.wrapPossibleInvalidUrlError(err);
+    }
   },
 
   /**

--- a/includes/error.js
+++ b/includes/error.js
@@ -90,10 +90,19 @@ function augmentMessage(err) {
   return err;
 }
 
+function wrapPossibleInvalidUrlError(err) {
+  if (err.code === 'ERR_INVALID_URL') {
+    // Wrap ERR_INVALID_URL in our own InvalidOption
+    return new BackupError('InvalidOption', err.message);
+  }
+  return err;
+}
+
 module.exports = {
-  BackupError: BackupError,
-  HTTPError: HTTPError,
-  convertResponseError: convertResponseError,
+  BackupError,
+  HTTPError,
+  wrapPossibleInvalidUrlError,
+  convertResponseError,
   terminationCallback: function terminationCallback(err, data) {
     if (err) {
       console.error(`ERROR: ${err.message}`);

--- a/test/app.js
+++ b/test/app.js
@@ -61,8 +61,8 @@ function releaseStderr() {
 }
 
 // Return a validation object for use with assert.rejects
-function assertErrorMessage(msg, name = 'InvalidOption') {
-  return { name, message: msg };
+function assertErrorMessage(msg) {
+  return { name: 'InvalidOption', message: msg };
 }
 
 // For cases where validation should pass we reach a real backup that hits a 404
@@ -77,10 +77,10 @@ describe('#unit Validate arguments', function() {
     return validateArgs(goodUrl, {}, assertNoValidationError());
   });
   it('returns error for invalid (no host) URL', async function() {
-    return validateArgs('http://', {}, assertErrorMessage('Invalid URL', 'TypeError'));
+    return validateArgs('http://', {}, assertErrorMessage('Invalid URL'));
   });
   it('returns error for invalid (no protocol) URL', async function() {
-    return validateArgs('invalid', {}, assertErrorMessage('Invalid URL', 'TypeError'));
+    return validateArgs('invalid', {}, assertErrorMessage('Invalid URL'));
   });
   it('returns error for invalid (wrong protocol) URL', async function() {
     return validateArgs('ftp://invalid.example.com', {}, assertErrorMessage('Invalid URL protocol.'));
@@ -89,7 +89,7 @@ describe('#unit Validate arguments', function() {
     return validateArgs('https://invalid.example.com', {}, assertErrorMessage('Invalid URL, missing path element (no database).'));
   });
   it('returns error for invalid (no protocol, no host) URL', async function() {
-    return validateArgs('invalid', {}, assertErrorMessage('Invalid URL', 'TypeError'));
+    return validateArgs('invalid', {}, assertErrorMessage('Invalid URL'));
   });
   it('returns error for invalid buffer size type', async function() {
     return validateArgs(goodUrl, { bufferSize: '123' }, assertErrorMessage('Invalid buffer size option, must be a positive integer in the range (0, MAX_SAFE_INTEGER]'));


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

fix: wrap ERR_INVALID_URL in InvalidOption

Fixes #635

## Approach

* Export new`wrapPossibleInvalidUrlError` from `error` module
    * function that checks for `ERR_INVALID_URL` and wraps it in `InvalidOption` type `BackupError`.
* To ensure that both places that construct a URL return the correct error type call `wrapPossibleInvalidUrlError` from
    * app.js
    * `cliutils.databaseUrl` 
* To ensure that the CLI process exits with the correct code add `try`/`catch` blocks to `couchbackup.bin.js` and `couchrestore.bin.js` that call the `error.terminationCallback` instead of an unhandled error if an error occurs before we are in the backup or restore functions.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because to remove `TypeError` from test assertions as it should have the correct `InvalidOption` type now.

## Monitoring and Logging

- "No change"
