### PR TITLE
refactor: replace liner with built-in readline

### DIFF
--- a/includes/logfilegetbatches.js
+++ b/includes/logfilegetbatches.js
@@ -15,7 +15,7 @@
 
 const fs = require('fs');
 const stream = require('stream');
-const liner = require('./liner.js');
+const { Liner } = require('./liner.js');
 
 const onLine = function(onCommand, batches) {
   const change = new stream.Transform({ objectMode: true });
@@ -64,7 +64,7 @@ module.exports = function(log, batches, callback) {
 
   // stream through the previous log file
   fs.createReadStream(log)
-    .pipe(liner())
+    .pipe(new Liner())
     .pipe(onLine(onCommand, batches))
     .on('error', function(err) {
       callback(err);

--- a/includes/logfilesummary.js
+++ b/includes/logfilesummary.js
@@ -15,7 +15,7 @@
 
 const fs = require('fs');
 const stream = require('stream');
-const liner = require('./liner.js');
+const { Liner } = require('./liner.js');
 
 const onLine = function(onCommand, getDocs) {
   const change = new stream.Transform({ objectMode: true });
@@ -83,7 +83,7 @@ module.exports = function(log, callback) {
 
   // stream through the previous log file
   fs.createReadStream(log)
-    .pipe(liner())
+    .pipe(new Liner())
     .pipe(onLine(onCommand, false))
     .on('finish', function() {
       const obj = { changesComplete: changesComplete, batches: state };

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -14,12 +14,12 @@
 'use strict';
 
 module.exports = function(db, options, readstream, ee, callback) {
-  const liner = require('../includes/liner.js')();
+  const { Liner } = require('../includes/liner.js');
   const writer = require('../includes/writer.js')(db, options.bufferSize, options.parallelism, ee);
 
   // pipe the input to the output, via transformation functions
   readstream
-    .pipe(liner) // transform the input stream into per-line
+    .pipe(new Liner()) // transform the input stream into per-line
     .on('error', function(err) {
       // Forward the error to the writer event emitter where we already have
       // listeners on for handling errors

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const fs = require('fs');
-const liner = require('./liner.js');
+const { Liner } = require('./liner.js');
 const change = require('./change.js');
 const error = require('./error.js');
 const debug = require('debug')('couchbackup:spoolchanges');
@@ -69,7 +69,7 @@ module.exports = function(db, log, bufferSize, ee, callback) {
     debug('making changes request since ' + since);
     return db.service.postChangesAsStream({ db: db.db, since: since, limit: limit, seqInterval: limit })
       .then(response => {
-        response.result.pipe(liner())
+        response.result.pipe(new Liner())
           .on('error', function(err) {
             logStream.end();
             callback(err);

--- a/test/writer.js
+++ b/test/writer.js
@@ -21,7 +21,7 @@ const nock = require('nock');
 const request = require('../includes/request.js');
 const writer = require('../includes/writer.js');
 const noopEmitter = new (require('events')).EventEmitter();
-const liner = require('../includes/liner.js');
+const { Liner } = require('../includes/liner.js');
 const { once } = require('node:events');
 const { pipeline } = require('node:stream/promises');
 const longTestTimeout = 3000;
@@ -40,7 +40,7 @@ describe('#unit Check database restore writer', function() {
       .reply(200, []); // success
 
     const w = writer(db, 500, 1, noopEmitter);
-    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), liner(), w),
+    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), new Liner(), w),
       once(w, 'finished').then((data) => {
         assert.strictEqual(data[0].total, 15);
         assert.ok(nock.isDone());
@@ -54,7 +54,7 @@ describe('#unit Check database restore writer', function() {
 
     const w = writer(db, 500, 1, noopEmitter);
     return assert.rejects(
-      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), liner(), w),
+      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), new Liner(), w),
       (err) => {
         assert.strictEqual(err.name, 'Unauthorized');
         assert.strictEqual(err.message, 'Access is denied due to invalid credentials.');
@@ -74,7 +74,7 @@ describe('#unit Check database restore writer', function() {
       .reply(200, { ok: true }); // third time lucky success
 
     const w = writer(db, 500, 1, noopEmitter);
-    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), liner(), w),
+    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), new Liner(), w),
       once(w, 'finished').then((data) => {
         assert.strictEqual(data[0].total, 15);
         assert.ok(nock.isDone());
@@ -92,7 +92,7 @@ describe('#unit Check database restore writer', function() {
 
     const w = writer(db, 500, 1, noopEmitter);
     return assert.rejects(
-      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), liner(), w),
+      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), new Liner(), w),
       (err) => {
         assert.strictEqual(err.name, 'HTTPFatalError');
         assert.strictEqual(err.message, `503 : post ${dbUrl}/_bulk_docs - Error: Service Unavailable`);
@@ -108,7 +108,7 @@ describe('#unit Check database restore writer', function() {
       .reply(200, [{ ok: true, id: 'foo', rev: '1-abc' }]); // success
 
     const w = writer(db, 500, 1, noopEmitter);
-    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_old_shallow.json'), liner(), w),
+    return Promise.all([pipeline(fs.createReadStream('./test/fixtures/animaldb_old_shallow.json'), new Liner(), w),
       once(w, 'finished').then((data) => {
         assert.strictEqual(data[0].total, 11);
         assert.ok(nock.isDone());
@@ -122,7 +122,7 @@ describe('#unit Check database restore writer', function() {
 
     const w = writer(db, 500, 1, noopEmitter);
     return assert.rejects(
-      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), liner(), w),
+      pipeline(fs.createReadStream('./test/fixtures/animaldb_expected.json'), new Liner(), w),
       (err) => {
         assert.strictEqual(err.name, 'Error');
         assert.strictEqual(err.message, 'Error writing batch with new_edits:false and 1 items');


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes - existing tests cover the code
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to feature branch
- [x] Completed the PR template below:

## Description

Replace custom liner with built-in readline.

Part of i251

## Approach

* Make a new `Liner` class that uses the built-in `node:readline` module.
* Extend a `Transform` stream to wrap the `readline` `createInterface`.
* Replace usages of `liner` with `Liner`.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests that use `liner` to use `Liner`
- No other new tests because the liner code is exercised by existing tests.

## Monitoring and Logging

- "No change"
