### PR TITLE
test: improve error handling in fatal errors suite

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-20T14:17:37Z",
+  "generated_at": "2023-10-26T17:26:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -172,7 +172,7 @@
         "hashed_secret": "ec4e1dbc7f64a0e052e855036f9470e7881f06fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 201,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test changes
- [x] Completed the PR template below:

## Description

Improve error handling in fatal errors suite.
Fixes #640 

## Approach

* Make `testPromiseWithAssertNock` and use it from all tests so the nock assertion can be controlled in one place.
* Move the `assertNock` from `then` to `finally` so that in cases where the test failed with an error we can see if nock was complete.
* Add an `error` event listener for the CLI test proxy and write a `400` result when errors are encountered. This prevents the proxy server blocking subsequent requests.
* Add a `no match` event listener for `nock` in the test `before` (and remove it in the `after`). This way any unmatched requests can be logged which makes debugging easier.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests as outlined above to fix #640.

## Monitoring and Logging

- "No change"
