### PR TITLE
Prepare 2.9.14 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.9.14 (2023-11-02)
 - [FIXED] Corrected error handling for invalid URLs.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.2`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.1.4` to match version provided from `@ibm-cloud/cloudant`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.14-SNAPSHOT",
+  "version": "2.9.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.14-SNAPSHOT",
+      "version": "2.9.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.14-SNAPSHOT",
+  "version": "2.9.14",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.14 release
# Changes
# 2.9.14 (2023-11-02)
- [FIXED] Corrected error handling for invalid URLs.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.2`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `4.1.4` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to minimum version `1.6.0` to match version provided from `ibm-cloud-sdk-core`.