### PR TITLE
refactor: add backup mapping functions

### DIFF
--- a/includes/backupMappings.js
+++ b/includes/backupMappings.js
@@ -1,0 +1,253 @@
+// Copyright © 2017, 2023 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const error = require('./error.js');
+const debug = require('debug');
+
+const mappingDebug = debug('couchbackup:mappings');
+
+const logMetadataRegex = /^(:(?:[td]\s+batch\d+|changes_complete))\s*/;
+const logCommandRegex = /^:([td]|changes_complete)/;
+const logBatchRegex = /batch(\d+)/;
+
+/**
+ * Function for splitting log file lines into summary and content sections.
+ *
+ * @param {string} logFileLine
+ * @returns {string[]} a max 2 element array, first element metadata, second element content
+ */
+function splitLogFileLine(logFileLine) {
+  if (logFileLine && logFileLine[0] === ':') {
+    // Allow up to 3 parts:
+    // 1. an empty string from the line start (will be discarded)
+    // 2. the capturing group from the split (the command/batch metadata)
+    // 3. any remaining content
+    const splitLine = logFileLine.split(logMetadataRegex, 3);
+    // First part of the split is an empty string because we split
+    // at the start of the line, so throw that out.
+    splitLine.shift();
+    return splitLine;
+  }
+  mappingDebug('Ignoring log file line does not start with :.');
+  return [];
+}
+
+/**
+ * Function to extract the command from the start of a log file line.
+ *
+ * @param {string} logLineMetadata the start of a log file line
+ * @returns command or null
+ */
+function getCommandFromMetadata(logLineMetadata) {
+  // extract command type
+  const commandMatches = logLineMetadata.match(logCommandRegex);
+  if (commandMatches) {
+    const command = commandMatches[1];
+    return command;
+  }
+  mappingDebug('Log line had no command.');
+  return null;
+}
+
+/**
+ * Function to extract the batch number from the start of a log file line.
+ *
+ * @param {string} logLineMetadata the start of a log file line
+ * @returns batch number or null
+ */
+function getBatchFromMetadata(logLineMetadata) {
+  // extract batch number
+  const batchMatches = logLineMetadata.match(logBatchRegex);
+  if (batchMatches) {
+    const batch = parseInt(batchMatches[1]);
+    return batch;
+  }
+  mappingDebug('Log line had no batch number.');
+  return null;
+}
+
+/**
+ * Function to parse the start of a log file line string into
+ * a backup batch object for the command and batch.
+ *
+ * @param {string} logLineMetadata
+ * @returns object with command, command and batch, or null
+ */
+function parseLogMetadata(logLineMetadata) {
+  const metadata = {};
+  mappingDebug(`Parsing log metadata ${logLineMetadata}`);
+  metadata.command = getCommandFromMetadata(logLineMetadata);
+  if (metadata.command) {
+    switch (metadata.command) {
+      case 't':
+      case 'd':
+        metadata.batch = getBatchFromMetadata(logLineMetadata);
+        if (metadata.batch === null) {
+          // For t and d we should have a batch, if not the line is broken
+          // reset the command
+          metadata.command = null;
+        } else {
+          mappingDebug(`Log file line for batch ${metadata.batch} with command ${metadata.command}.`);
+        }
+        break;
+      case 'changes_complete':
+        mappingDebug(`Log file line for command ${metadata.command}.`);
+        break;
+      default:
+        mappingDebug(`Unknown command ${metadata.command} in log file`);
+        break;
+    }
+  }
+  return metadata;
+}
+
+function handleLogLine(logFileLine, metadataOnly = false) {
+  mappingDebug(`Parsing line ${logFileLine}`);
+  let metadata = {};
+  const backupBatch = { command: null, batch: null, docs: [] };
+  // Split the line into command/batch metadata and remaining contents
+  const splitLogLine = splitLogFileLine(logFileLine);
+  if (splitLogLine.length >= 1) {
+    metadata = parseLogMetadata(splitLogLine[0]);
+    // type 't' entries have doc IDs to parse
+    if (!metadataOnly && metadata.command === 't' && splitLogLine.length === 2) {
+      const logFileContentJson = splitLogLine[1];
+      try {
+        backupBatch.docs = JSON.parse(logFileContentJson);
+        mappingDebug(`Parsed ${backupBatch.docs.length} from log file line for batch ${metadata.batch}.`);
+      } catch (err) {
+        mappingDebug(`Ignoring parsing error ${err}`);
+        // Line is broken, discard metadata
+        metadata = {};
+      }
+    }
+  } else {
+    mappingDebug('Ignoring empty or unknown line in log file.');
+  }
+  return { ...backupBatch, ...metadata };
+}
+
+/**
+ *
+ * This is used to create a batch completeness log without
+ * needing to parse all the document ID information.
+ *
+ */
+function logLineToMetadata(logFileLine) {
+  return handleLogLine(logFileLine, true);
+}
+
+/**
+ * Mapper for converting log file lines to batch objects.
+ *
+ * @param {string} logFileLine
+ * @returns {object} a batch object {command: t|d|changes_complete, batch: #, docs: [{id: id, ...}]}
+ */
+function logLineToBackupBatch(logFileLine) {
+  return handleLogLine(logFileLine);
+}
+
+/**
+ * Mapper for converting a backup batch to a backup file line
+ *
+ * @param {object} backupBatch a backup batch object {command: d, batch: #, docs: [{_id: id, ...}, ...]}
+ * @returns {string} JSON string for the backup file
+ */
+function backupBatchToBackupFileLine(backupBatch) {
+  mappingDebug(`Stringifying batch ${backupBatch.batch} with ${backupBatch.docs.length} docs.`);
+  return JSON.stringify(backupBatch.docs) + '\n';
+}
+
+/**
+ * Mapper for converting a backup batch to a log file line
+ *
+ * @param {object} backupBatch a backup batch object {command: d, batch: #, docs: [{_id: id, ...}, ...]}
+ * @returns {string} log file batch done line
+ */
+function backupBatchToLogFileLine(backupBatch) {
+  mappingDebug(`Preparing log batch completion line for batch ${backupBatch.batch}.`);
+  return `:d batch${backupBatch.batch}\n`;
+}
+
+/**
+ * Return a mapping function for the specified db that maps a batch of pending
+ * document IDs to fetched documents via a _bulk_get call.
+ *
+ * @param {object} db representation of the database connection
+ * @returns a mapper function
+ */
+function getPendingToFetchedMapper(db) {
+  /**
+   * Mapper for converting a type t "to do" backup batch object (docs IDs to fetch)
+   * to a type d "done" backup batch object with the retrieved docs.
+   *
+   * @param {object} backupBatch  {command: t, batch: #, docs: [{id: id}, ...]}
+   * @returns {object} a backup batch object {command: d, batch: #, docs: [{_id: id, ...}, ...]}
+   */
+  return async function backupBatchToBulkGetResponse(backupBatch) {
+    mappingDebug(`Fetching batch ${backupBatch.batch}.`);
+    return await db.service.postBulkGet({
+      db: db.db,
+      revs: true,
+      docs: backupBatch.docs
+    }).then(response => {
+      mappingDebug(`Good server response for batch ${backupBatch.batch}.`);
+      // create an output array with the docs returned
+      // Bulk get response "results" array is of objects {id: "id", docs: [...]}
+      // Since "docs" is an array too we use a flatMap
+      const documentRevisions = response.result.results.flatMap(entry => {
+        // for each entry in "results" we map the "docs" array
+        if (entry.docs) {
+          // Map the "docs" array entries to the document revision inside the "ok" property
+          return entry.docs.map((doc) => {
+            if (doc.ok) {
+              // This is the fetched document revision
+              return doc.ok;
+            }
+            if (doc.error) {
+              // This type of error was ignored previously so just debug for now.
+              mappingDebug(`Error ${doc.error.error} for ${doc.error.id} in batch ${backupBatch.batch}.`);
+            }
+            return null;
+          }).filter((doc) => {
+            // Filter out any entries that didn't have a document revision
+            return doc || false;
+          });
+        }
+        // Fallback to an empty array that will add nothing to the fetched docs array
+        return [];
+      });
+
+      mappingDebug(`Server returned ${documentRevisions.length} document revisions for batch ${backupBatch.batch}.`);
+
+      return {
+        command: 'd',
+        batch: backupBatch.batch,
+        docs: documentRevisions
+      };
+    }).catch(err => {
+      mappingDebug(`Error response from server for batch ${backupBatch.batch}.`);
+      throw error.convertResponseError(err);
+    });
+  };
+}
+
+module.exports = {
+  backupBatchToBackupFileLine,
+  backupBatchToLogFileLine,
+  getPendingToFetchedMapper,
+  logLineToBackupBatch,
+  logLineToMetadata
+};

--- a/test/backupMappings.js
+++ b/test/backupMappings.js
@@ -1,0 +1,159 @@
+// Copyright © 2023 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global afterEach beforeEach describe it */
+'use strict';
+
+const assert = require('node:assert');
+const request = require('../includes/request.js');
+const { backupBatchToBackupFileLine, backupBatchToLogFileLine, getPendingToFetchedMapper, logLineToBackupBatch, logLineToMetadata } = require('../includes/backupMappings.js');
+
+function assertFileLine(fileLine, expectedContent) {
+  assert.ok(fileLine, 'There should be a file line.');
+  assert.equal(typeof fileLine, 'string', 'The file line should be a string.');
+  assert.equal(fileLine, expectedContent, 'The file line should have the correct content.');
+}
+
+function assertBackupBatchObject(backupBatch, expectedCommand, expectedBatch, expectedDocs) {
+  assert.ok(backupBatch, 'The mapped value should be truthy.');
+  assert.strictEqual(typeof backupBatch, 'object');
+  assert.strictEqual(backupBatch.command, expectedCommand);
+  assert.strictEqual(backupBatch.batch, expectedBatch);
+  assert.deepStrictEqual(backupBatch.docs, expectedDocs);
+}
+
+describe('#unit backup mappings', function() {
+  const backupBatchTodo = { command: 't', batch: 0, docs: [{ id: 'doc1' }, { id: 'doc2' }] };
+  const backupBatchDone = { command: 't', batch: 0, docs: [{ _id: 'doc1', hello: 'world' }, { _id: 'doc2', foo: 'bar' }] };
+
+  describe('backupBatchToBackupFileLine', function() {
+    it('should correctly map to a backup line', function() {
+      const fileLine = backupBatchToBackupFileLine(backupBatchDone);
+      assertFileLine(fileLine, `${JSON.stringify(backupBatchDone.docs)}\n`);
+    });
+  });
+
+  describe('backupBatchToLogFileLine', function() {
+    it('should correctly map to a log file line', function() {
+      const fileLine = backupBatchToLogFileLine(backupBatchDone);
+      assertFileLine(fileLine, ':d batch0\n');
+    });
+  });
+
+  describe('log line mappers', function() {
+    const makeTestForLogLine = (fn, logLine, expected) => {
+      return function() {
+        const backupBatch = fn(logLine);
+        if (fn.name === logLineToMetadata.name) {
+          // In the metadata only cases we expect no docs
+          expected[2] = [];
+        }
+        assertBackupBatchObject(backupBatch, ...expected);
+      };
+    };
+
+    [logLineToBackupBatch, logLineToMetadata].forEach((fn) => {
+      describe(`${fn.name}`, function() {
+        it('should correctly map a todo log file line (static)',
+          makeTestForLogLine(fn,
+            ':t batch42 [{"id": "doc420"}, {"id": "doc421"}]',
+            ['t', 42, [{ id: 'doc420' }, { id: 'doc421' }]]
+          )
+        );
+        it('should correctly map a todo log file line (dynamic)',
+          makeTestForLogLine(fn,
+            `:t batch${backupBatchTodo.batch} ${JSON.stringify(backupBatchTodo.docs)}`,
+            ['t', 0, backupBatchTodo.docs]
+          )
+        );
+        it('should correctly map a done log file line',
+          makeTestForLogLine(fn,
+            ':d batch357',
+            ['d', 357, []]
+          )
+        );
+        it('should correctly map a changes_complete log file line',
+          makeTestForLogLine(fn,
+            ':changes_complete',
+            ['changes_complete', null, []]
+          )
+        );
+        it('should correctly map a changes_complete log file line with trailing info',
+          makeTestForLogLine(fn,
+            ':changes_complete 2345-abcdef123456',
+            ['changes_complete', null, []]
+          )
+        );
+        it('should correctly map a changes_complete log file line with undefined',
+          makeTestForLogLine(fn,
+            ':changes_complete undefined',
+            ['changes_complete', null, []]
+          )
+        );
+        it('should handle corrupted content log file lines',
+          // Note this is explcitly testing partial lines, when fn is invoked
+          // it should not throw an exception. If it does the test will fail.
+          makeTestForLogLine(fn,
+            ':t batch42 [{"id": "doc', // note this specifically tests a partial line
+            fn.name === logLineToMetadata.name
+              ? ['t', 42, []] // metadata case, metadata is valid content is ignored anyway
+              : [null, null, []] // batch case, broken content means line ignored
+          )
+        );
+        it('should handle corrupted metadata log file lines',
+        // Note this is explcitly testing partial lines, when fn is invoked
+        // it should not throw an exception. If it does the test will fail.
+          makeTestForLogLine(fn,
+            ':d batc', // note this specifically tests a partial line
+            [null, null, []] // broken metadata, line ignored
+          )
+        );
+      });
+    });
+  });
+
+  describe('getPendingToFetchedMapper', function() {
+    const nock = require('nock');
+    const url = 'http://localhost:7777';
+    const dbName = 'fakenockdb';
+    const db = request.client(`${url}/${dbName}`, { parallelism: 1 });
+    const fetcher = getPendingToFetchedMapper(db);
+
+    beforeEach('setup nock', function() {
+      nock(url)
+        .post(`/${dbName}/_bulk_get`)
+        .query(true)
+        .times(1)
+        .reply(200, (uri, requestBody) => {
+          // mock a _bulk_get response
+          return JSON.stringify({
+            results: [
+              { docs: backupBatchDone.docs.map((doc) => { return { ok: doc }; }) }
+            ]
+          });
+        });
+    });
+
+    afterEach('setup nock', function() {
+      nock.cleanAll();
+    });
+
+    it('should correctly map a batch from todo to done', async function() {
+      return fetcher(backupBatchTodo).then((fetchedBatch) => {
+        assertBackupBatchObject(fetchedBatch, 'd', 0, backupBatchDone.docs);
+        assert.ok(nock.isDone, 'The mocks should be done');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - targeting `modernization` feature branch, cahnges will be updated later
- [x] Completed the PR template below:

## Description

Add backup mapping functions for use in future pipeline.

Fixes i258

## Approach

Created 5 mapping functions (and some unexported helper functions).
Some of the code is copied from existing `backup.js` and `logfile*.js` - the code in those files is still active until we start using these mapping functions in pipeline transforms later on.

The inputs and outputs are:
file lines (either log or backup)
backup batch objects of the form `{command: t|d|changes_complete, batch: #, docs: []}`

The mapping functions are:
| function | input | output | purpose |
| --- | --- | --- | --- |
| backupBatchToBackupFileLine | `{command: 'd', batch: #, docs: [full docs]}` | stringified docs | wiriting backup file |
| backupBatchToLogFileLine | `{command: 'd', batch: #, docs: []}` | `:d batch#` log file line | writing log file |
| getPendingToFetchedMapper | `{command: 't', batch: #, docs: [ids]}` | `{command: 'd', batch: #, docs: [full docs]}` | fetching batches of revisions |
| logLineToBackupBatch | `:t batch# stringified array of ids` | `{command: 't', batch: #, docs: [ids]}` | converting changes log to batches to fetch
| logLineToMetadata | `:command batch# ...` | `{command, batch: #}` | calculating progress for resume cases

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests for each mapping function.

## Monitoring and Logging

- Added debug logging in the mapping functions.
