### PR TITLE
Add PassThrough stream that performs side effects

### DIFF
--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -86,8 +86,29 @@ class SplittingStream extends Duplex {
   }
 }
 
+class SideEffect extends PassThrough {
+  constructor(fn, options) {
+    super(options);
+    this.fn = fn;
+  }
+
+  async doSideEffect(chunk) {
+    return await this.fn(chunk);
+  }
+
+  _transform(chunk, encoding, callback) {
+    this.doSideEffect(chunk)
+      .then(() => {
+        super._transform(chunk, encoding, callback);
+      }).catch((err) => {
+        callback(err);
+      });
+  }
+}
+
 module.exports = {
   BatchingStream,
   MappingStream,
-  SplittingStream
+  SplittingStream,
+  SideEffect
 };


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description
Add `PassThrough` stream that performs side effects
Fixes i252
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
- Add new `SideEffect` class that accepts a custom function
- Non-async functions are handled in `async doSideEffect`
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Added tests to assert side effect by passing in sync and async functions.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
