### PR TITLE
test: intermittent failures in fatal error tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-26T17:26:38Z",
+  "generated_at": "2023-11-23T11:02:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -172,7 +172,7 @@
         "hashed_secret": "ec4e1dbc7f64a0e052e855036f9470e7881f06fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 205,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -76,6 +76,10 @@ async function restoreHttpError(opts, errorName, errorCode) {
 
 [{ useApi: true }, { useApi: false }].forEach(function(params) {
   describe(u.scenario('#unit Fatal errors', params), function() {
+    // These tests do real requests with mocks and if they run slowly
+    // the 2 second default mocha timeout can be insufficient, use 10 s
+    this.timeout(10000);
+
     let processEnvCopy;
     let proxy;
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test only
- [x] Completed the PR template below:

## Description

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run the fatal error tests repeatedly on a busy system.

### 2. What you expected to happen

All tests to pass.

### 3. What actually happened

The test intermittently fail (particularly the CLI restore tests).
These tests fork a new Node process and also make real requests against mocks (via a proxy).
This amount of work seems to sometimes trigger the default 2s test timeout on busy systems.

## Approach

Inrease the test timeout for these tests to 10 s.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests as outlined above. I tested 15 builds with the increased timeout and did not see any failures, previously the timeout failure would occur approximately 1 in 5.

## Monitoring and Logging

- "No change"
