### PR TITLE
refactor: writable wrappers

### DIFF
--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -80,23 +80,9 @@ class MappingStream extends Duplex {
 }
 
 /**
- * Input: stream of arrays
- * Output: stream of elements
+ * PassThrough stream that calls another function
+ * to perform a side effect.
  */
-class SplittingStream extends Duplex {
-  constructor(concurrency = 1, outHighWaterMarkScale = 500, inHighWaterMarkScale = 1) {
-    const inputStream = new PassThrough({ objectMode: true, readableHighWaterMark: concurrency * outHighWaterMarkScale, writableHighWaterMark: concurrency * inHighWaterMarkScale });
-    return Duplex.from({
-      objectMode: true,
-      readable: inputStream.flatMap(
-        (input) => {
-          return input;
-        }, { concurrency }),
-      writable: inputStream
-    });
-  }
-}
-
 class SideEffect extends PassThrough {
   constructor(fn, options) {
     super(options);
@@ -117,10 +103,28 @@ class SideEffect extends PassThrough {
   }
 }
 
+/**
+ * Input: stream of arrays
+ * Output: stream of elements
+ */
+class SplittingStream extends Duplex {
+  constructor(concurrency = 1, outHighWaterMarkScale = 500, inHighWaterMarkScale = 1) {
+    const inputStream = new PassThrough({ objectMode: true, readableHighWaterMark: concurrency * outHighWaterMarkScale, writableHighWaterMark: concurrency * inHighWaterMarkScale });
+    return Duplex.from({
+      objectMode: true,
+      readable: inputStream.flatMap(
+        (input) => {
+          return input;
+        }, { concurrency }),
+      writable: inputStream
+    });
+  }
+}
+
 module.exports = {
   BatchingStream,
   FilterStream,
   MappingStream,
-  SplittingStream,
-  SideEffect
+  SideEffect,
+  SplittingStream
 };

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -23,7 +23,7 @@ const { BatchingStream, MappingStream, SplittingStream, SideEffect, FilterStream
 const events = require('events');
 
 describe('#unit should do transforms', function() {
-  describe('batching', async function() {
+  describe('BatchingStream', async function() {
     async function testBatching(elements, batchSize) {
       let batchCounter = 0;
       let fullBatchCounter = 0;
@@ -84,43 +84,8 @@ describe('#unit should do transforms', function() {
     });
   });
 
-  describe('splitting', async function() {
-    async function testSplitting(elements, batchSize, concurrency) {
-      let elementCounter = 0;
-      return pipeline(Readable.from(Array(elements).keys()), new BatchingStream(batchSize), new SplittingStream(concurrency),
-        new Writable({
-          objectMode: true,
-          write(chunk, encoding, callback) {
-            elementCounter++;
-            callback();
-          }
-        })).then(() => {
-        assert.strictEqual(elementCounter, elements, 'There should be the correct number of elements.');
-      });
-    }
 
-    it('single batch', async function() {
-      return testSplitting(2, 2);
-    });
-
-    it('multiple batches, same size', async function() {
-      return testSplitting(15, 3);
-    });
-
-    it('multiple batches, different size', async function() {
-      return testSplitting(29, 8);
-    });
-
-    it('multiple batches, concurrency', async function() {
-      return testSplitting(25, 5, 5);
-    });
-
-    it('multiple batches, different size, concurrency', async function() {
-      return testSplitting(27, 5, 5);
-    });
-  });
-
-  describe('mapping', async function() {
+  describe('MappingStream', async function() {
     async function testMapping(input, mapping, expected, concurrency) {
       const output = new PassThrough({ objectMode: true });
       return pipeline(input, new MappingStream(mapping, concurrency), output).then(() => {
@@ -155,7 +120,7 @@ describe('#unit should do transforms', function() {
     });
   });
 
-  describe('side effect', async function() {
+  describe('SideEffect', async function() {
     // Test "streams"
     const singleElement = [{ id: '01' }];
     const multipleElements = [{ id: '01' }, { id: '02' }, { id: '03' }];
@@ -256,6 +221,42 @@ describe('#unit should do transforms', function() {
           assert.strictEqual(counter, 2);
         });
       });
+    });
+  });
+
+  describe('SplittingStream', async function() {
+    async function testSplitting(elements, batchSize, concurrency) {
+      let elementCounter = 0;
+      return pipeline(Readable.from(Array(elements).keys()), new BatchingStream(batchSize), new SplittingStream(concurrency),
+        new Writable({
+          objectMode: true,
+          write(chunk, encoding, callback) {
+            elementCounter++;
+            callback();
+          }
+        })).then(() => {
+        assert.strictEqual(elementCounter, elements, 'There should be the correct number of elements.');
+      });
+    }
+
+    it('single batch', async function() {
+      return testSplitting(2, 2);
+    });
+
+    it('multiple batches, same size', async function() {
+      return testSplitting(15, 3);
+    });
+
+    it('multiple batches, different size', async function() {
+      return testSplitting(29, 8);
+    });
+
+    it('multiple batches, concurrency', async function() {
+      return testSplitting(25, 5, 5);
+    });
+
+    it('multiple batches, different size, concurrency', async function() {
+      return testSplitting(27, 5, 5);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization` changes will be updated later.
- [x] Completed the PR template below:

## Description

Add `Writable` instances that delegate to another `Writable`.

Fixes i259

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

* Re-ordered transforms and renamed test describe blocks
* Added 2 new classes:
    * `DelegateWritable` - a `Writable` implementation that simply delegates to another `Writable`. Special handling is added for `process.stdout`. It is not "endable" while the process is running so we need to detect that case to use it at the end of a pipeline.
    * `WritablePassThrough` - a special case of the `SideEffect` pass through that uses a `DelegateWritable` for performing side effects. This allows for the case of writing a log file from a middle stage of a pipeline.
* Updated `spoolchanges` to use the `DelegateWritable` as much of the functionality was similar to the `LogWriter` there.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests in `test/transform.js` for:
    - `DelegateWritable`
    - `WritablePassThrough`

## Monitoring and Logging

- Added logging throughout new classes.
