### PR TITLE
refactor: backup mappings

### DIFF
--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -61,6 +61,17 @@ class BatchingStream extends Transform {
  * Input: stream of x
  * Output: stream of mappingFunction(x)
  */
+class FilterStream extends Duplex {
+  constructor(filterFunction) {
+    const inputStream = new PassThrough({ objectMode: true });
+    return Duplex.from({ readable: inputStream.filter(filterFunction), writable: inputStream });
+  }
+}
+
+/**
+ * Input: stream of x
+ * Output: stream of mappingFunction(x)
+ */
 class MappingStream extends Duplex {
   constructor(mappingFunction, concurrency = 1) {
     const inputStream = new PassThrough({ objectMode: true, highWaterMark: concurrency * 2 });
@@ -108,6 +119,7 @@ class SideEffect extends PassThrough {
 
 module.exports = {
   BatchingStream,
+  FilterStream,
   MappingStream,
   SplittingStream,
   SideEffect

--- a/test/backupMappings.js
+++ b/test/backupMappings.js
@@ -17,6 +17,7 @@
 
 const assert = require('node:assert');
 const request = require('../includes/request.js');
+const { Liner } = require('../includes/liner.js');
 const { Backup, LogMapper } = require('../includes/backupMappings.js');
 
 function assertFileLine(fileLine, expectedContent) {
@@ -52,8 +53,10 @@ describe('#unit backup mappings', function() {
   });
 
   describe('log line mappers', function() {
+    const liner = new Liner(true);
     const logMapper = new LogMapper();
     const makeTestForLogLine = (fn, logLine, expected) => {
+      logLine = liner.wrapLine(logLine);
       return function() {
         const backupBatch = fn(logLine);
         if (fn.name === logMapper.logLineToMetadata.name) {

--- a/test/fixtures/test2.log
+++ b/test/fixtures/test2.log
@@ -1,0 +1,4 @@
+:t batch0 [{"id":"1"},{"id":"2"}]
+:t batch1 [{"id":"3"},{"id":"4"}]
+:t batch2 [{"id":"5"},{"id":"6"}]
+:changes_complete 1-abcetc

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -19,7 +19,7 @@ const assert = require('node:assert');
 const tp = require('node:timers/promises');
 const { Readable, Writable, PassThrough } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
-const { BatchingStream, MappingStream, SplittingStream, SideEffect } = require('../includes/transforms.js');
+const { BatchingStream, MappingStream, SplittingStream, SideEffect, FilterStream } = require('../includes/transforms.js');
 const events = require('events');
 
 describe('#unit should do transforms', function() {
@@ -74,6 +74,16 @@ describe('#unit should do transforms', function() {
       return testBatching(25, 4);
     });
   });
+
+  describe('FilterStream', async function() {
+    it('should filter', async function() {
+      const out = new PassThrough({ objectMode: true });
+      await pipeline([1, 2, 3, 4, 5, 6], new FilterStream((i) => { return i % 2 === 0; }), out);
+      const actual = await out.toArray();
+      assert.deepStrictEqual(actual, [2, 4, 6]);
+    });
+  });
+
   describe('splitting', async function() {
     async function testSplitting(elements, batchSize, concurrency) {
       let elementCounter = 0;


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization` changes will be updated later
- [x] Completed the PR template below:

## Description

Modifications to the work delivered in #652 to bring it more in line with what was done in #658.

Fixes part of i258

## Approach

* Move the mapping functions into two classes `LogMapper` and `Backup`.
* Use the `Liner` object format with line numbers in the mapping functions.
* Make the `pendingToFetched` use the same `await`/`try`/`catch` style as `pendingToRestored`.
* Add a new `FilterStream` (missed from #654).
* Add end to end testing of the mapping.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - `FilterStream` testing
    - `end to end mapping` test using a pipeline

- Modified existing backup mapping tests to use the Liner object format delivered in #658.

## Monitoring and Logging

- Minor tweaks to debug loginng.
