### PR TITLE
refactor: Promisify backup and restore pre-flight checks

### DIFF
--- a/includes/error.js
+++ b/includes/error.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2021 IBM Corp. All rights reserved.
+// Copyright © 2017, 2023 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,12 @@ class BackupError extends Error {
   constructor(name, message) {
     super(message);
     this.name = name;
+  }
+}
+
+class OptionError extends BackupError {
+  constructor(message) {
+    super('InvalidOption', message);
   }
 }
 
@@ -93,13 +99,14 @@ function augmentMessage(err) {
 function wrapPossibleInvalidUrlError(err) {
   if (err.code === 'ERR_INVALID_URL') {
     // Wrap ERR_INVALID_URL in our own InvalidOption
-    return new BackupError('InvalidOption', err.message);
+    return new OptionError(err.message);
   }
   return err;
 }
 
 module.exports = {
   BackupError,
+  OptionError,
   HTTPError,
   wrapPossibleInvalidUrlError,
   convertResponseError,


### PR DESCRIPTION
This is an async rewrite of pre-flight checks for backup and restore functions to do a pre-work to conversion from internal event emitter + callbacks to streams rewrite.

The steps done: 

- Simplify and DRY `validateArgs` in `app.js`
- Convert all validation functions to `async`, convert backup/restore to use them in promise chain fashion. 

