### PR TITLE
Prepare 2.9.15 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.9.15 (2023-12-04)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.0`.
+- [NOTE] Updated Node.js version requirement statement for LTS 18 and 20.
+
 # 2.9.14 (2023-11-02)
 - [FIXED] Corrected error handling for invalid URLs.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.7.2`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.15-SNAPSHOT",
+  "version": "2.9.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.15-SNAPSHOT",
+      "version": "2.9.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.15-SNAPSHOT",
+  "version": "2.9.15",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
# Proposed 2.9.15 release
## Changes
### 2.9.15 (2023-12-04)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.0`.
- [NOTE] Updated Node.js version requirement statement for LTS 18 and 20.