### PR TITLE
refactor: backup pipeline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-08T12:07:17Z",
+  "generated_at": "2023-12-13T15:03:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -214,7 +214,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-23T11:02:43Z",
+  "generated_at": "2023-12-08T12:07:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -172,7 +172,7 @@
         "hashed_secret": "ec4e1dbc7f64a0e052e855036f9470e7881f06fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 207,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/app.js
+++ b/app.js
@@ -423,7 +423,8 @@ module.exports = {
           objectMode: true,
           write: (restoreBatch, encoding, cb) => {
             debug(' restored ', restoreBatch.total);
-            total = restoreBatch.total;
+            // order not guaranteed
+            if (total < restoreBatch.total) total = restoreBatch.total;
             try {
               ee.emit('restored', restoreBatch);
             } finally {

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -13,267 +13,81 @@
 // limitations under the License.
 'use strict';
 
-const async = require('async');
-const events = require('events');
-const fs = require('fs');
-const error = require('./error.js');
+const { createWriteStream } = require('node:fs');
+const { pipeline } = require('node:stream/promises');
+const { Backup } = require('./backupMappings.js');
+const { BackupError, convertResponseError } = require('./error.js');
+const logFileSummary = require('./logfilesummary.js');
+const logFileGetBatches = require('./logfilegetbatches.js');
 const spoolchanges = require('./spoolchanges.js');
-const logfilesummary = require('./logfilesummary.js');
-const logfilegetbatches = require('./logfilegetbatches.js');
-
-/**
- * Read documents from a database to be backed up.
- *
- * @param {string} db - `@cloudant/cloudant` DB object for source database.
- * @param {number} blocksize - number of documents to download in single request
- * @param {number} parallelism - number of concurrent downloads
- * @param {string} log - path to log file to use
- * @param {boolean} resume - whether to resume from an existing log file
- * @returns EventEmitter with following events:
- *  - `received` - called with a block of documents to write to backup
- *  - `error` - on error
- *  - `finished` - when backup process is finished (either complete or errored)
- */
-module.exports = function(db, options) {
-  const ee = new events.EventEmitter();
-  const start = new Date().getTime(); // backup start time
-  const batchesPerDownloadSession = 50; // max batches to read from log file for download at a time (prevent OOM)
-
-  function proceedWithBackup() {
-    if (options.resume) {
-      // pick up from existing log file from previous run
-      downloadRemainingBatches(options.log, db, ee, start, batchesPerDownloadSession, options.parallelism);
-    } else {
-      // create new log file and process
-      spoolchanges(db, options.log, options.bufferSize).then(() => {
-        downloadRemainingBatches(options.log, db, ee, start, batchesPerDownloadSession, options.parallelism);
-      }).catch((err) => {
-        ee.emit('error', err);
-      });
-    }
-  }
-
-  validateBulkGetSupport(db, function(err) {
-    if (err) {
-      return ee.emit('error', err);
-    } else {
-      proceedWithBackup();
-    }
-  });
-
-  return ee;
-};
+const { MappingStream, WritableWithPassThrough, DelegateWritable } = require('./transforms.js');
 
 /**
  * Validate /_bulk_get support for a specified database.
  *
- * @param {string} db - nodejs-cloudant db
- * @param {function} callback - called on completion with signature (err)
+ * @param {object} db - object for connection to source database containing name, service and url
  */
-function validateBulkGetSupport(db, callback) {
-  db.service.postBulkGet({ db: db.db, docs: [] }).then(() => { callback(); }).catch(err => {
-    err = error.convertResponseError(err, function(err) {
-      switch (err.status) {
-        case undefined:
-          // There was no status code on the error
-          return err;
-        case 404:
-          return new error.BackupError('BulkGetError', 'Database does not support /_bulk_get endpoint');
-        default:
-          return new error.HTTPError(err);
-      }
-    });
-    callback(err);
-  });
-}
-
-/**
- * Download remaining batches in a log file, splitting batches into sets
- * to avoid enqueueing too many in one go.
- *
- * @param {string} log - log file name to maintain download state
- * @param {string} db - nodejs-cloudant db
- * @param {events.EventEmitter} ee - event emitter to emit received events on
- * @param {time} startTime - start time for backup process
- * @param {number} batchesPerDownloadSession - max batches to enqueue for
- *  download at a time. As batches contain many doc IDs, this helps avoid
- *  exhausting memory.
- * @param {number} parallelism - number of concurrent downloads
- * @returns function to call do download remaining batches with signature
- *  (err, {batches: batch, docs: doccount}) {@see spoolchanges}.
- */
-function downloadRemainingBatches(log, db, ee, startTime, batchesPerDownloadSession, parallelism) {
-  let total = 0; // running total of documents downloaded so far
-  let noRemainingBatches = false;
-
-  // Generate a set of batches (up to batchesPerDownloadSession) to download from the
-  // log file and download them. Set noRemainingBatches to `true` for last batch.
-  function downloadSingleBatchSet(done) {
-    // Fetch the doc IDs for the batches in the current set to
-    // download them.
-    function batchSetComplete(err, data) {
-      if (!err) {
-        total = data.total;
-      }
-      done(err);
-    }
-    function processRetrievedBatches(err, batches) {
-      if (!err) {
-        // process them in parallelised queue
-        processBatchSet(db, parallelism, log, batches, ee, startTime, total, batchSetComplete);
-      } else {
-        batchSetComplete(err);
-      }
-    }
-
-    readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, function(err, batchSetIds) {
-      if (err) {
-        ee.emit('error', err);
-        // Stop processing changes file for fatal errors
-        noRemainingBatches = true;
-        done();
-      } else {
-        if (batchSetIds.length === 0) {
-          noRemainingBatches = true;
-          return done();
-        }
-        logfilegetbatches(log, batchSetIds, processRetrievedBatches);
-      }
-    });
-  }
-
-  // Return true if all batches in log file have been downloaded
-  function isFinished(callback) { callback(null, noRemainingBatches); }
-
-  function onComplete() {
-    ee.emit('finished', { total: total });
-  }
-
-  async.doUntil(downloadSingleBatchSet, isFinished, onComplete);
-}
-
-/**
- * Return a set of uncompleted download batch IDs from the log file.
- *
- * @param {string} log - log file path
- * @param {number} batchesPerDownloadSession - maximum IDs to return
- * @param {function} callback - sign (err, batchSetIds array)
- */
-function readBatchSetIdsFromLogFile(log, batchesPerDownloadSession, callback) {
-  logfilesummary(log, function processSummary(err, summary) {
-    if (!err) {
-      if (!summary.changesComplete) {
-        callback(new error.BackupError('IncompleteChangesInLogFile',
-          'WARNING: Changes did not finish spooling'));
-        return;
-      }
-      if (Object.keys(summary.batches).length === 0) {
-        return callback(null, []);
-      }
-
-      // batch IDs are the property names of summary.batches
-      const batchSetIds = getPropertyNames(summary.batches, batchesPerDownloadSession);
-      callback(null, batchSetIds);
+async function validateBulkGetSupport(db) {
+  try {
+    await db.service.postBulkGet({ db: db.db, docs: [] });
+  } catch (err) {
+    // if _bulk_get isn't available throw a special error
+    if (err.status === 404) {
+      throw new BackupError('BulkGetError', 'Database does not support /_bulk_get endpoint');
     } else {
-      callback(err);
+      throw err;
     }
-  });
+  }
 }
 
 /**
- * Download a set of batches retrieved from a log file. When a download is
- * complete, add a line to the logfile indicating such.
+ * Read documents from a database to be backed up.
  *
- * @param {any} db - nodejs-cloudant database
- * @param {any} parallelism - number of concurrent requests to make
- * @param {any} log - log file to drive downloads from
- * @param {any} batches - batches to download
- * @param {any} ee - event emitter for progress. This funciton emits
- *  received and error events.
- * @param {any} start - time backup started, to report deltas
- * @param {any} grandtotal - count of documents downloaded prior to this set
- *  of batches
- * @param {any} callback - completion callback, (err, {total: number}).
+ * @param {object} db - object for connection to source database containing name, service and url
+ * @param {number} options - backup configuration
+ * @param {Writable} targetStream - destination for the backup contents
+ * @param {EventEmitter} ee - user facing event emitter
+ * @returns pipeline promise that resolves for a successful backup or rejects on failure
  */
-function processBatchSet(db, parallelism, log, batches, ee, start, grandtotal, callback) {
-  let hasErrored = false;
-  let total = grandtotal;
-
-  // queue to process the fetch requests in an orderly fashion using _bulk_get
-  const q = async.queue(function(payload, done) {
-    const output = [];
-    const thisBatch = payload.batch;
-    delete payload.batch;
-    delete payload.command;
-
-    function logCompletedBatch(batch) {
-      if (log) {
-        fs.appendFile(log, ':d batch' + thisBatch + '\n', done);
-      } else {
-        done();
-      }
-    }
-
-    // do the /db/_bulk_get request
-    db.service.postBulkGet({
-      db: db.db,
-      revs: true,
-      docs: payload.docs
-    }).then(response => {
-      // create an output array with the docs returned
-      response.result.results.forEach(function(d) {
-        if (d.docs) {
-          d.docs.forEach(function(doc) {
-            if (doc.ok) {
-              output.push(doc.ok);
-            }
-          });
+module.exports = function(db, options, targetStream) {
+  // Full backups use _bulk_get, validate it is available
+  return validateBulkGetSupport(db)
+  // Check if the backup is new or resuming and configure the source
+    .then(async() => {
+      if (options.resume) {
+      // Resuming a backup, get the log file summary
+      // (changes complete and remaining batch numbers to backup)
+        const summary = await logFileSummary(options.log);
+        if (!summary.changesComplete) {
+        // We can only resume if changes had finished spooling
+          throw new BackupError('IncompleteChangesInLogFile',
+            'WARNING: Changes did not finish spooling, a backup can only be resumed if changes finished spooling. Start a new backup.');
         }
-      });
-      total += output.length;
-      const t = (new Date().getTime() - start) / 1000;
-      ee.emit('received', {
-        batch: thisBatch,
-        data: output,
-        length: output.length,
-        time: t,
-        total: total
-      }, q, logCompletedBatch);
-    }).catch(err => {
-      if (!hasErrored) {
-        hasErrored = true;
-        err = error.convertResponseError(err);
-        // Kill the queue for fatal errors
-        q.kill();
-        ee.emit('error', err);
+        return logFileGetBatches(options.log, summary.batches);
+      } else {
+      // Not resuming, start from spooling changes
+        return spoolchanges(db, options.log, options.bufferSize);
       }
-      done();
-    });
-  }, parallelism);
-
-  for (const i in batches) {
-    q.push(batches[i]);
-  }
-
-  q.drain(function() {
-    callback(null, { total: total });
-  });
-}
-
-/**
- * Returns first N properties on an object.
- *
- * @param {object} obj - object with properties
- * @param {number} count - number of properties to return
- */
-function getPropertyNames(obj, count) {
-  // decide which batch numbers to deal with
-  const batchestofetch = [];
-  let j = 0;
-  for (const i in obj) {
-    batchestofetch.push(parseInt(i));
-    j++;
-    if (j >= count) break;
-  }
-  return batchestofetch;
-}
+    })
+  // Create a pipeline of the source streams and the backup mappings
+    .then((srcStreams) => {
+      const backup = new Backup(db);
+      return pipeline(
+        ...srcStreams, // the source streams from the previous block (spool changes or resumed log)
+        new MappingStream(backup.pendingToFetched, options.parallelism), // fetch the batches at the configured concurrency
+        new WritableWithPassThrough(
+          'backup', // name for logging
+          targetStream, // backup file
+          null, // no need to write a last chunk
+          backup.backupBatchToBackupFileLine // map the backup batch to a string for the backup file
+        ), // WritableWithPassThrough writes the fetched docs to the backup file and passes on the result metadata
+        new DelegateWritable(
+          'logFileDoneWriter', // Name for debug
+          createWriteStream(options.log, { flags: 'a' }), // log file for appending
+          null, // no last chunk to write
+          backup.backupBatchToLogFileLine // Map the backed up batch result to a log file "done" line
+        ) // DelegateWritable writes the log file done lines
+      );
+    })
+    .catch((e) => { throw convertResponseError(e); });
+};

--- a/includes/error.js
+++ b/includes/error.js
@@ -70,8 +70,15 @@ function checkResponse(err) {
     if (err.status >= 400) {
       return new HTTPError(err);
     } else {
+      // Historically we have a special error for problems during changes spooling.
+      // To maintain compatibility we check if the error was related to a changes request
+      // and return the special error.
+      if (err.message.includes('_changes')) {
+        return new BackupError('SpoolChangesError', `Failed changes request - ${err.message}`);
+      } else {
       // Send it back again if there was no status code, e.g. a cxn error
-      return augmentMessage(err);
+        return augmentMessage(err);
+      }
     }
   }
 }

--- a/includes/logfilegetbatches.js
+++ b/includes/logfilegetbatches.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2023 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,63 +13,28 @@
 // limitations under the License.
 'use strict';
 
-const fs = require('fs');
-const stream = require('stream');
+const fs = require('node:fs');
+const { LogMapper } = require('./backupMappings.js');
 const { Liner } = require('./liner.js');
+const { FilterStream, MappingStream } = require('./transforms.js');
 
-const onLine = function(onCommand, batches) {
-  const change = new stream.Transform({ objectMode: true });
-  change._transform = function(line, encoding, done) {
-    if (line && line[0] === ':') {
-      const obj = {
-        command: null,
-        batch: null,
-        docs: []
-      };
-
-      let matches;
-
-      // extract command
-      matches = line.match(/^:([a-z_]+) ?/);
-      if (matches) {
-        obj.command = matches[1];
-      }
-
-      // extract batch
-      matches = line.match(/ batch([0-9]+)/);
-      if (matches) {
-        obj.batch = parseInt(matches[1]);
-      }
-
-      // if this is one we want
-      if (obj.command === 't' && batches.indexOf(obj.batch) > -1) {
-        const json = line.replace(/^.* batch[0-9]+ /, '').trim();
-        obj.docs = JSON.parse(json);
-        onCommand(obj);
-      }
-    }
-    done();
-  };
-  return change;
-};
-
-module.exports = function(log, batches, callback) {
-  // our sense of state
-  const retval = { };
-
-  // called with each line from the log file
-  const onCommand = function(obj) {
-    retval[obj.batch] = obj;
-  };
-
-  // stream through the previous log file
-  fs.createReadStream(log)
-    .pipe(new Liner())
-    .pipe(onLine(onCommand, batches))
-    .on('error', function(err) {
-      callback(err);
-    })
-    .on('finish', function() {
-      callback(null, retval);
-    });
+/**
+ * Return an array of streams that when pipelined will produce
+ * pending backup batches from a log file.
+ *
+ * @param {string} log - log file name
+ * @param {Map} batches - a log summary batches Map of pending batch numbers
+ * @returns a log summary object
+ */
+module.exports = function(log, batches) {
+  const logMapper = new LogMapper();
+  return [
+    fs.createReadStream(log), // log file
+    new Liner(true), // split it into lines
+    new MappingStream(logMapper.logLineToBackupBatch), // parse line to a backup batch
+    new FilterStream((metadata) => {
+      // delete returns true if the key exists, false otherwise
+      return batches.delete(metadata.batch);
+    }) // filter out already done batches
+  ];
 };

--- a/includes/logfilesummary.js
+++ b/includes/logfilesummary.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2023 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,80 +13,50 @@
 // limitations under the License.
 'use strict';
 
-const fs = require('fs');
-const stream = require('stream');
+const { createReadStream } = require('node:fs');
+const { Writable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 const { Liner } = require('./liner.js');
-
-const onLine = function(onCommand, getDocs) {
-  const change = new stream.Transform({ objectMode: true });
-
-  change._transform = function(line, encoding, done) {
-    if (line && line[0] === ':') {
-      const obj = {
-        command: null,
-        batch: null,
-        docs: []
-      };
-
-      let matches;
-
-      // extract command
-      matches = line.match(/^:([a-z_]+) ?/);
-      if (matches) {
-        obj.command = matches[1];
-      }
-
-      // extract batch
-      matches = line.match(/ batch([0-9]+)/);
-      if (matches) {
-        obj.batch = parseInt(matches[1]);
-      }
-
-      // extract doc ids
-      if (getDocs && obj.command === 't') {
-        const json = line.replace(/^.* batch[0-9]+ /, '').trim();
-        obj.docs = JSON.parse(json);
-      }
-      onCommand(obj);
-    }
-    done();
-  };
-  return change;
-};
+const { LogMapper } = require('./backupMappings.js');
+const { MappingStream } = require('./transforms.js');
 
 /**
  * Generate a list of remaining batches from a download file.
+ * Creates a summary containing a changesComplete boolean for
+ * if the :changes_complete log file entry was found and a map
+ * of pending batch numbers that have yet to be backed up
+ * (i.e. the difference of :t and :d log file entries).
  *
  * @param {string} log - log file name
- * @param {function} callback - callback with err, {changesComplete: N, batches: N}.
- *  changesComplete signifies whether the log file appeared to
- *  have completed reading the changes feed (contains :changes_complete).
- *  batches are remaining batch IDs for download.
+ * @returns a log summary object
  */
-module.exports = function(log, callback) {
-  // our sense of state
-  const state = {
+module.exports = async function(log) {
+  const logMapper = new LogMapper();
+  const state = { changesComplete: false, batches: new Map() };
 
-  };
-  let changesComplete = false;
-
-  // called with each line from the log file
-  const onCommand = function(obj) {
-    if (obj.command === 't') {
-      state[obj.batch] = true;
-    } else if (obj.command === 'd') {
-      delete state[obj.batch];
-    } else if (obj.command === 'changes_complete') {
-      changesComplete = true;
-    }
-  };
-
-  // stream through the previous log file
-  fs.createReadStream(log)
-    .pipe(new Liner())
-    .pipe(onLine(onCommand, false))
-    .on('finish', function() {
-      const obj = { changesComplete: changesComplete, batches: state };
-      callback(null, obj);
-    });
+  await pipeline(
+    createReadStream(log), // read the log file
+    new Liner(true), // split it into lines
+    new MappingStream(logMapper.logLineToMetadata), // parse line to metadata
+    new Writable({
+      objectMode: true,
+      write: (metadata, encoding, callback) => {
+        switch (metadata.command) {
+          case 't':
+            state.batches.set(metadata.batch, true);
+            break;
+          case 'd':
+            state.batches.delete(metadata.batch);
+            break;
+          case 'changes_complete':
+            state.changesComplete = true;
+            break;
+          default:
+            break;
+        }
+        callback();
+      }
+    }) // Save the done batch number in an array
+  );
+  return state;
 };

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -56,7 +56,7 @@ module.exports = function(db, log, bufferSize, tolerance = 600000) {
         // Extract the document ID from the change
         return { id: changeResultItem.id };
       } else {
-        throw new error.BackupError('InvalidChange', `Received invalid change: ${changeResultItem}`);
+        throw new error.BackupError('SpoolChangesError', `Received invalid change: ${JSON.stringify(changeResultItem)}`);
       }
     });
   };
@@ -83,11 +83,4 @@ module.exports = function(db, log, bufferSize, tolerance = 600000) {
     new MappingStream(mapChangesBatchToBackupBatch), // map a batch of ChangesResultItem to doc IDs
     new LogWriter(log)
   ];
-  // .catch((err) => {
-  //   if (err.status && err.status >= 400) {
-  //     return Promise.reject(error.convertResponseError(err));
-  //   } else if (err.name !== 'SpoolChangesError') {
-  //     return Promise.reject(new error.BackupError('SpoolChangesError', `Failed changes request - ${err.message}`));
-  //   }
-  // })
 };

--- a/test/fatalerrors.js
+++ b/test/fatalerrors.js
@@ -198,13 +198,15 @@ async function restoreHttpError(opts, errorName, errorCode) {
         // Allow the existence and _bulk_get checks to pass
         const n = nock(url).head('/fakenockdb').reply(200);
         n.post('/fakenockdb/_bulk_get').reply(200, '{"results": []}');
-        // Simulate a changes without a last_seq
+        // Simulate _changes response with invalid changes property
         n.post('/fakenockdb/_changes').query(true).reply(200,
           {
+            last_seq: '2-blahblah',
+            pending: 0,
             results: [{
               seq: '2-g1AAAAEbeJzLYWBgYMlgTmFQSElKzi9KdUhJstTLTS3KLElMT9VLzskvTUnMK9HLSy3JAapkSmRIsv___39WBnMiUy5QgN3MzDIxOdEMWb85dv0gSxThigyN8diS5AAkk-pBFiUyoOkzxKMvjwVIMjQAKaDW_Zh6TQnqPQDRC7I3CwDPDV1k',
               id: 'badger',
-              changes: [{ rev: '4-51aa94e4b0ef37271082033bba52b850' }]
+              changes: [] // Invalid test, no revs here
             }]
           });
         return backupHttpError(params, 'SpoolChangesError', 30);

--- a/test/logfilegetbatches.js
+++ b/test/logfilegetbatches.js
@@ -16,26 +16,30 @@
 'use strict';
 
 const assert = require('assert');
-const logfilegetbatches = require('../includes/logfilegetbatches.js');
+const { Writable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+const logFileGetBatches = require('../includes/logfilegetbatches.js');
 
 describe('#unit Fetching batches from a log file', function() {
   it('should fetch multiple batches correctly', async function() {
-    return new Promise((resolve, reject) => {
-      logfilegetbatches('./test/fixtures/test.log', [1, 4], function(err, data) {
-        try {
-          assert.ok(!err);
-          assert.ok(data);
-          assert.strictEqual(typeof data, 'object');
-          assert.strictEqual(Object.keys(data).length, 2);
-          assert.deepStrictEqual(data['1'].docs, [{ id: '6' }, { id: '7' }, { id: '8' }, { id: '9' }, { id: '10' }]);
-          assert.strictEqual(data['1'].batch, 1);
-          assert.deepStrictEqual(data['4'].docs, [{ id: '21' }, { id: '22' }]);
-          assert.strictEqual(data['4'].batch, 4);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      });
-    });
+    const output = [];
+    // Test to get batches 1 and 4
+    const summaryBatches = new Map().set(1, true).set(4, true);
+    // Make a pipeline from the logFileGetBatches source
+    await pipeline(...logFileGetBatches('./test/fixtures/test.log', summaryBatches), new Writable({
+      objectMode: true,
+      write: (chunk, encoding, callback) => {
+        output.push(chunk);
+        callback();
+      }
+    }));
+
+    // Output array should contain 2 backup batch objects
+    // one for batch 1 and one for batch 4
+    const expected = [
+      { command: 't', batch: 1, docs: [{ id: '6' }, { id: '7' }, { id: '8' }, { id: '9' }, { id: '10' }] },
+      { command: 't', batch: 4, docs: [{ id: '21' }, { id: '22' }] }
+    ];
+    assert.deepStrictEqual(output, expected);
   });
 });

--- a/test/logfilesummary.js
+++ b/test/logfilesummary.js
@@ -16,25 +16,16 @@
 'use strict';
 
 const assert = require('assert');
-const logfilesummary = require('../includes/logfilesummary.js');
+const logFileSummary = require('../includes/logfilesummary.js');
 
 describe('#unit Fetching summary from the log file', function() {
-  it('should fetch a summary correctly', function() {
-    return new Promise((resolve, reject) => {
-      logfilesummary('./test/fixtures/test.log', function(err, data) {
-        try {
-          assert.ok(!err);
-          assert.ok(data);
-          assert.strictEqual(data.changesComplete, true);
-          assert.strictEqual(typeof data.batches, 'object');
-          assert.strictEqual(Object.keys(data.batches).length, 2);
-          assert.deepStrictEqual(data.batches['1'], true);
-          assert.deepStrictEqual(data.batches['4'], true);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      });
-    });
+  it('should fetch a summary correctly', async function() {
+    const summary = await logFileSummary('./test/fixtures/test.log');
+    assert.ok(summary);
+    assert.strictEqual(summary.changesComplete, true);
+    assert.ok(summary.batches instanceof Map);
+    assert.strictEqual(summary.batches.size, 2);
+    assert.deepStrictEqual(summary.batches.get(1), true);
+    assert.deepStrictEqual(summary.batches.get(4), true);
   });
 });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization` changes will be updated later
- [x] Completed the PR template below:

## Description

Migrate the full backup functionality to a streams pipeline.

Fixes i264 and i265.

## Approach

* refactor: resume log file handling
    * Replace JS object with `Map` for storing state
    * `logFileSummary` replaced with a pipeline that reads log file metadata only and resolves with a summary of pending batch numbers
    * `logFileGetBatches` returns an array of streams that can be composed into a pipeline that maps log file data to pending backup batches
* refactor: spoolchanges for backup pipeline & fix: spool changes uses non-existent error name
    * changed to return an array of streams that can be composed into a pipeline that streams changes and adds pending batches to a log file
    * fix a bug where an invalid change used an error name not present in `errors.js`
    * make `LogWriter` a `WritableWithPassThrough` so that it can log a pending batch and pass on the backupBatch to be used later in the pipeline
* refactor: full backup as pipeline
    * Full backup in app.js becomes a promise that when resolved/rejected triggers the user callback (existing code moves into shallow backup only for now)
    * replace the backupFull function with a pipeline promise composed of a source from either a log file resume or spool changes followed by complete backup batch fetch/write/log.
* refactor: event emitters
     * add a `SideEffect` to emit `changes` events after they are received and logged
     * add a `postWriteFn` to the backup destination `Writable` so that it emits the `written` event after the batch has been written to the file
* fix: restore totals
    * fixes a bug where restored totals were out of order

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests:
    - log file tests updated to use new interfaces described above
    - spool changes tests
        - updated to use interface above with a common function to compose a pipeline for the tests and convert the errors caught in the pipeline
        - updated fatalerrors test to use an invalid change
    - test: fix write error test
        - this test was not working as designed, the `EACCES` error was being thrown from the `createWriteStream` and not from inside backup code. This also meant the backup was running in the background and could cause subsequent tests to fail. Just pass a `Readable` stream into the API instead to prove the backup fails if it can't write.

## Monitoring and Logging

- Some debug logging is replaced by new logging in transforms and backupMappings.
