### PR TITLE
reafctor: request class cleanup and renames

### DIFF
--- a/includes/backupMappings.js
+++ b/includes/backupMappings.js
@@ -172,8 +172,8 @@ class LogMapper {
 }
 
 class Backup {
-  constructor(db) {
-    this.db = db;
+  constructor(dbClient) {
+    this.dbClient = dbClient;
   }
 
   /**
@@ -208,8 +208,8 @@ class Backup {
   pendingToFetched = async(backupBatch) => {
     mappingDebug(`Fetching batch ${backupBatch.batch}.`);
     try {
-      const response = await this.db.service.postBulkGet({
-        db: this.db.db,
+      const response = await this.dbClient.service.postBulkGet({
+        db: this.dbClient.dbName,
         revs: true,
         docs: backupBatch.docs
       });

--- a/includes/request.js
+++ b/includes/request.js
@@ -78,7 +78,7 @@ const errorHelper = async function(err) {
 };
 
 module.exports = {
-  client: function(rawUrl, opts) {
+  newClient: function(rawUrl, opts) {
     const url = new URL(rawUrl);
     // Split the URL to separate service from database
     // Use origin as the "base" to remove auth elements
@@ -153,6 +153,6 @@ module.exports = {
       return requestConfig;
     }, null);
 
-    return { service, db: dbName, url: actUrl.toString() };
+    return { service, dbName, url: actUrl.toString() };
   }
 };

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -18,8 +18,8 @@ const { Restore } = require('../includes/restoreMappings.js');
 const { BatchingStream, MappingStream, SplittingStream } = require('./transforms.js');
 const { pipeline } = require('node:stream/promises');
 
-module.exports = function(db, options, readstream, outputWritable) {
-  const restore = new Restore(db);
+module.exports = function(dbClient, options, readstream, outputWritable) {
+  const restore = new Restore(dbClient);
 
   return pipeline(
     readstream, // the backup file

--- a/includes/restoreMappings.js
+++ b/includes/restoreMappings.js
@@ -19,8 +19,8 @@ const debug = require('debug');
 const mappingDebug = debug('couchbackup:mappings');
 
 class Restore {
-  constructor(db) {
-    this.db = db;
+  constructor(dbClient) {
+    this.dbClient = dbClient;
     this.totalDocsRestored = 0;
     this.batchCounter = 0;
   }
@@ -91,8 +91,8 @@ class Restore {
       mappingDebug('Using new_edits false mode.');
     }
     try {
-      const response = await this.db.service.postBulkDocs({
-        db: this.db.db,
+      const response = await this.dbClient.service.postBulkDocs({
+        db: this.dbClient.dbName,
         bulkDocs: restoreBatch
       });
       if (!response.result || (restoreBatch.new_edits === false && response.result.length > 0)) {

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -17,7 +17,7 @@ const async = require('async');
 const error = require('./error.js');
 const events = require('events');
 
-module.exports = function(db, options) {
+module.exports = function(dbClient, options) {
   const ee = new events.EventEmitter();
   const start = new Date().getTime();
   let batch = 0;
@@ -29,14 +29,14 @@ module.exports = function(db, options) {
     function(callback) {
       // Note, include_docs: true is set automatically when using the
       // fetch function.
-      const opts = { db: db.db, limit: options.bufferSize, includeDocs: true };
+      const opts = { db: dbClient.dbName, limit: options.bufferSize, includeDocs: true };
 
       // To avoid double fetching a document solely for the purposes of getting
       // the next ID to use as a startKey for the next page we instead use the
       // last ID of the current page and append the lowest unicode sort
       // character.
       if (startKey) opts.startKey = `${startKey}\0`;
-      db.service.postAllDocs(opts).then(response => {
+      dbClient.service.postAllDocs(opts).then(response => {
         const body = response.result;
         if (!body.rows) {
           ee.emit('error', new error.BackupError(

--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -23,12 +23,12 @@ const { ChangesFollower } = require('@ibm-cloud/cloudant');
  * Write log file for all changes from a database, ready for downloading
  * in batches.
  *
- * @param {object} db - object for connection to source database containing name, service and url
+ * @param {object} dbClient - object for connection to source database containing name, service and url
  * @param {string} log - path to log file to use
  * @param {number} bufferSize - the number of changes per batch/log line
  * @param {number} tolerance - changes follower error tolerance
  */
-module.exports = function(db, log, bufferSize, tolerance = 600000) {
+module.exports = function(dbClient, log, bufferSize, tolerance = 600000) {
   let lastSeq;
   let batch = 0;
   let totalBuffer = 0;
@@ -72,11 +72,11 @@ module.exports = function(db, log, bufferSize, tolerance = 600000) {
   };
 
   const changesParams = {
-    db: db.db,
+    db: dbClient.dbName,
     seqInterval: 10000
   };
 
-  const changesFollower = new ChangesFollower(db.service, changesParams, tolerance);
+  const changesFollower = new ChangesFollower(dbClient.service, changesParams, tolerance);
   return [
     changesFollower.startOneOff(), // stream of changes from the DB
     new BatchingStream(bufferSize), // group changes into bufferSize batches for mapping

--- a/test/backupMappings.js
+++ b/test/backupMappings.js
@@ -19,7 +19,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
-const request = require('../includes/request.js');
+const { newClient } = require('../includes/request.js');
 const { Liner } = require('../includes/liner.js');
 const { FilterStream, MappingStream } = require('../includes/transforms.js');
 const { Backup, LogMapper } = require('../includes/backupMappings.js');
@@ -135,8 +135,8 @@ describe('#unit backup mappings', function() {
     const nock = require('nock');
     const url = 'http://localhost:7777';
     const dbName = 'fakenockdb';
-    const db = request.client(`${url}/${dbName}`, { parallelism: 1 });
-    const fetcher = new Backup(db).pendingToFetched;
+    const dbClient = newClient(`${url}/${dbName}`, { parallelism: 1 });
+    const fetcher = new Backup(dbClient).pendingToFetched;
 
     beforeEach('setup nock', function() {
       nock(url)
@@ -170,7 +170,7 @@ describe('#unit backup mappings', function() {
       const nock = require('nock');
       const url = 'http://localhost:7777';
       const dbName = 'fakenockdb';
-      const db = request.client(`${url}/${dbName}`, { parallelism: 1 });
+      const dbClient = newClient(`${url}/${dbName}`, { parallelism: 1 });
 
       const expected = [];
 
@@ -193,7 +193,7 @@ describe('#unit backup mappings', function() {
           };
         });
 
-      const backup = new Backup(db);
+      const backup = new Backup(dbClient);
       const output = [];
       return pipeline(
         fs.createReadStream('./test/fixtures/test2.log'), // read the log

--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -26,7 +26,7 @@ const { Tail } = require('tail');
 const app = require('../app.js');
 const dbUrl = require('../includes/cliutils.js').databaseUrl;
 const compare = require('./compare.js');
-const request = require('../includes/request.js');
+const { newClient } = require('../includes/request.js');
 const { cliBackup, cliDecrypt, cliEncrypt, cliGzip, cliGunzip, cliRestore } = require('./test_process.js');
 const testLogger = debug('couchbackup:test:utils');
 
@@ -360,7 +360,7 @@ async function testBackupAbortResumeRestore(params, srcDb, backupFile, targetDb)
 }
 
 async function dbCompare(db1Name, db2Name) {
-  const client = request.client(process.env.COUCH_BACKEND_URL, {});
+  const client = newClient(process.env.COUCH_BACKEND_URL, {});
   return compare.compare(db1Name, db2Name, client.service)
     .then(result => {
       return assert.strictEqual(result, true, 'The database comparison should succeed, but failed');

--- a/test/restore.js
+++ b/test/restore.js
@@ -18,14 +18,14 @@
 const assert = require('assert');
 const fs = require('fs');
 const nock = require('nock');
-const request = require('../includes/request.js');
+const { newClient } = require('../includes/request.js');
 const restorePipeline = require('../includes/restore.js');
 const { DelegateWritable } = require('../includes/transforms.js');
 const longTestTimeout = 3000;
 
 describe('#unit Check database restore writer', function() {
   const dbUrl = 'http://localhost:5984/animaldb';
-  const db = request.client(dbUrl, { parallelism: 1 });
+  const dbClient = newClient(dbUrl, { parallelism: 1 });
 
   beforeEach('Reset nocks', function() {
     nock.cleanAll();
@@ -35,7 +35,7 @@ describe('#unit Check database restore writer', function() {
     let runningTotal = 0;
     let lastTotal;
     return restorePipeline(
-      db,
+      dbClient,
       { bufferSize: 500, parallelism: 1 },
       fs.createReadStream(fileName),
       new DelegateWritable('null', fs.createWriteStream('/dev/null'), null, () => { return ''; }, (restoreResult) => {

--- a/test/shallowbackup.js
+++ b/test/shallowbackup.js
@@ -17,17 +17,17 @@
 
 const assert = require('assert');
 const backup = require('../includes/shallowbackup.js');
-const request = require('../includes/request.js');
+const { newClient } = require('../includes/request.js');
 const fs = require('fs');
 const nock = require('nock');
 
 // Function to create a DB object and call the shallow backup function
 // This is normally done by app.js
 function shallowBackup(dbUrl, opts) {
-  const db = request.client(dbUrl, opts);
+  const dbClient = newClient(dbUrl, opts);
   // Disable compression to make body assertions easier
-  db.service.setEnableGzipCompression(false);
-  return backup(db, opts);
+  dbClient.service.setEnableGzipCompression(false);
+  return backup(dbClient, opts);
 }
 
 // Note all these tests include a body parameter of include_docs and a query


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization` changes will be updated later
- [x] Completed the PR template below:

## Description

Update the request class.

Fixes i313

## Approach

* Remove obsolete code for handling streams that is no longer needed.
* Fix some lint errors for object shorthand.
* Renames as proposed in https://github.com/IBM/couchbackup/pull/669#discussion_r1424275938
    * function `client` -> `newClient`
    * returned client object `db` -> `dbName`
    * usages of the object renamed from `db` to `dbClient`

## Schema & API Changes

- Internal renames.

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to match new names.

## Monitoring and Logging

- Added debugging in interceptor.
