### PR TITLE
refactor: common error handling

### DIFF
--- a/includes/backup.js
+++ b/includes/backup.js
@@ -16,7 +16,7 @@
 const { createWriteStream } = require('node:fs');
 const { pipeline } = require('node:stream/promises');
 const { Backup } = require('./backupMappings.js');
-const { BackupError, convertResponseError } = require('./error.js');
+const { BackupError } = require('./error.js');
 const logFileSummary = require('./logfilesummary.js');
 const logFileGetBatches = require('./logfilegetbatches.js');
 const spoolchanges = require('./spoolchanges.js');
@@ -103,6 +103,5 @@ module.exports = function(dbClient, options, targetStream, ee) {
     })
     .then(() => {
       ee.emit('finished', { total });
-    })
-    .catch((e) => { throw convertResponseError(e); });
+    });
 };

--- a/includes/backupMappings.js
+++ b/includes/backupMappings.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 'use strict';
 
-const error = require('./error.js');
 const debug = require('debug');
 
 const mappingDebug = debug('couchbackup:mappings');
@@ -250,7 +249,7 @@ class Backup {
       };
     } catch (err) {
       mappingDebug(`Error response from server for batch ${backupBatch.batch}.`);
-      throw error.convertResponseError(err);
+      throw err;
     }
   };
 }

--- a/includes/restoreMappings.js
+++ b/includes/restoreMappings.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 'use strict';
 
-const error = require('./error.js');
+const { BackupError } = require('./error.js');
 const debug = require('debug');
 
 const mappingDebug = debug('couchbackup:mappings');
@@ -40,7 +40,7 @@ class Restore {
       } catch (err) {
         // If the line can't be parsed as JSON it is most likely an incomplete write.
         // If the backup was resumed we can ignore the error because the line will be repeated.
-        const parseError = new error.BackupError('BackupFileJsonError', `Error on line ${backupLine.lineNumber} of backup file - cannot parse as JSON`);
+        const parseError = new BackupError('BackupFileJsonError', `Error on line ${backupLine.lineNumber} of backup file - cannot parse as JSON`);
         // If the backup wasn't resumed then it is invalid and we should error, but we have no way to detect this atm.
         mappingDebug(`${parseError}`);
         // Return an empty array if there was an ignorable line
@@ -50,7 +50,7 @@ class Restore {
       if (arr && Array.isArray(arr)) {
         return arr;
       } else {
-        throw new error.BackupError('BackupFileJsonError', `Error on line ${backupLine.lineNumber} of backup file - not an array`);
+        throw new BackupError('BackupFileJsonError', `Error on line ${backupLine.lineNumber} of backup file - not an array`);
       }
     }
     // Return an empty array if there was a blank line
@@ -104,9 +104,8 @@ class Restore {
       this.totalDocsRestored += restoreBatch.docs.length;
       return { batch, documents: restoreBatch.docs.length, total: this.totalDocsRestored };
     } catch (err) {
-      const errToThrow = error.convertResponseError(err);
-      mappingDebug(`Error writing docs ${errToThrow.name} ${errToThrow.message} when restoring batch ${batch}`);
-      throw errToThrow;
+      mappingDebug(`Error writing docs when restoring batch ${batch}`);
+      throw err;
     }
   };
 }

--- a/includes/shallowbackup.js
+++ b/includes/shallowbackup.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const async = require('async');
-const error = require('./error.js');
+const { convertError, BackupError } = require('./error.js');
 const events = require('events');
 
 module.exports = function(dbClient, options) {
@@ -39,7 +39,7 @@ module.exports = function(dbClient, options) {
       dbClient.service.postAllDocs(opts).then(response => {
         const body = response.result;
         if (!body.rows) {
-          ee.emit('error', new error.BackupError(
+          ee.emit('error', new BackupError(
             'AllDocsError', 'ERROR: Invalid all docs response'));
           callback();
         } else {
@@ -66,7 +66,7 @@ module.exports = function(dbClient, options) {
           callback();
         }
       }).catch(err => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         ee.emit('error', err);
         hasErrored = true;
         callback();

--- a/test/request.js
+++ b/test/request.js
@@ -18,7 +18,7 @@
 const assert = require('assert');
 const nock = require('nock');
 const { newClient } = require('../includes/request.js');
-const error = require('../includes/error.js');
+const { convertError } = require('../includes/error.js');
 
 const url = 'http://localhost:7777/testdb';
 const dbClient = newClient(url, { parallelism: 1 });
@@ -66,7 +66,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       dbClient.service.getDocument({ db: dbClient.dbName, docId: 'bad' }),
       (err) => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         assert.strictEqual(err.name, 'HTTPFatalError');
         assert.strictEqual(err.message, `500 Internal Server Error: get ${url}/bad - Error: foo, Reason: bar`);
         assert.ok(couch.isDone());
@@ -87,7 +87,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       dbClient.service.postBulkGet({ db: dbClient.dbName, revs: true, docs: [] }),
       (err) => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         assert.strictEqual(err.name, 'HTTPFatalError');
         assert.strictEqual(err.message, `503 Service Unavailable: post ${url}/_bulk_get - Error: service_unavailable, Reason: Service unavailable`);
         assert.ok(couch.isDone());
@@ -107,7 +107,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       dbClient.service.getDocument({ db: dbClient.dbName, docId: 'bad' }),
       (err) => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         assert.strictEqual(err.name, 'HTTPFatalError');
         assert.strictEqual(err.message, `429 Too Many Requests: get ${url}/bad - Error: foo, Reason: bar`);
         assert.ok(couch.isDone());
@@ -126,7 +126,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       dbClient.service.getDocument({ db: dbClient.dbName, docId: 'bad' }),
       (err) => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         assert.strictEqual(err.name, 'HTTPFatalError');
         assert.strictEqual(err.message, `404 Not Found: get ${url}/bad - Error: foo, Reason: bar`);
         assert.ok(couch.isDone());
@@ -143,7 +143,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       dbClient.service.getDocument({ db: dbClient.dbName, docId: 'bad' }),
       (err) => {
-        const err2 = error.convertResponseError(err);
+        const err2 = convertError(err);
         assert.strictEqual(err, err2);
         assert.ok(couch.isDone());
         return true;
@@ -183,7 +183,7 @@ describe('#unit Check request response error callback', function() {
     return assert.rejects(
       timeoutDbClient.service.postBulkGet({ db: dbClient.dbName, revs: true, docs: [] }),
       (err) => {
-        err = error.convertResponseError(err);
+        err = convertError(err);
         // Note axios returns ECONNABORTED rather than ESOCKETTIMEDOUT
         // See https://github.com/axios/axios/issues/2710 via https://github.com/axios/axios/issues/1543`
         assert.strictEqual(err.statusText, 'ECONNABORTED');

--- a/test/restore.js
+++ b/test/restore.js
@@ -21,6 +21,7 @@ const nock = require('nock');
 const { newClient } = require('../includes/request.js');
 const restorePipeline = require('../includes/restore.js');
 const { DelegateWritable } = require('../includes/transforms.js');
+const { convertError } = require('../includes/error.js');
 const longTestTimeout = 3000;
 
 describe('#unit Check database restore writer', function() {
@@ -46,6 +47,10 @@ describe('#unit Check database restore writer', function() {
       assert.strictEqual(runningTotal, lastTotal);
       assert.ok(nock.isDone());
       return lastTotal;
+    }).catch((e) => {
+      // Error conversion takes place in the top level functions
+      // so to facilitate unit testing we just do the same conversion here.
+      throw convertError(e);
     });
   }
 

--- a/test/restoreMappings.js
+++ b/test/restoreMappings.js
@@ -22,6 +22,7 @@ const { Liner } = require('../includes/liner.js');
 const { newClient } = require('../includes/request.js');
 const { Restore } = require('../includes/restoreMappings.js');
 const { MappingStream } = require('../includes/transforms.js');
+const { convertError } = require('../includes/error.js');
 
 describe('#unit restore mappings', function() {
   const testDocs = [
@@ -172,7 +173,9 @@ describe('#unit restore mappings', function() {
 
       // pendingToRestored modifies objects in place, so take a copy otherwise we might impact other tests
       const source = testBatches.map((batch) => { return { ...batch }; });
-      return assert.rejects(pipeline(source, new MappingStream(new Restore(dbClient).pendingToRestored), outputAsWritable([])),
+      return assert.rejects(
+        pipeline(source, new MappingStream(new Restore(dbClient).pendingToRestored), outputAsWritable([]))
+          .catch((e) => { throw convertError(e); }), // perform an error conversion as would happen at the top level
         { name: 'HTTPFatalError' }
       ).then(() => { assert.ok(nock.isDone(), 'The mocks should all be called.'); });
     });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization` changes will be updated later
- [x] Completed the PR template below:

## Description

Simplify error handling.

Fixes i269

## Approach

* Rename `convertResponseError` to `convertError`
* Combine error conversion functionality in single function
* Move conversion calls to `app.js` at end of pipeline

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because in places the test code needs to call `convertError` to make the assertions easier.

## Monitoring and Logging

- "No change"
