### PR TITLE
refactor: event emitters

### DIFF
--- a/app.js
+++ b/app.js
@@ -375,7 +375,10 @@ module.exports = {
           }
 
           return backupFull(backupDbClient, opts, targetStream, ee)
-            .then(callback); // TODO move after shallow backup is refactored
+            .then((total) => {
+              ee.emit('finished', total);
+              callback(null, total); // TODO move after shallow backup is refactored
+            });
         }
       })
       .catch(e => callback(convertError(e)));

--- a/includes/backup.js
+++ b/includes/backup.js
@@ -102,6 +102,6 @@ module.exports = function(dbClient, options, targetStream, ee) {
       );
     })
     .then(() => {
-      ee.emit('finished', { total });
+      return { total };
     });
 };

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -13,13 +13,38 @@
 // limitations under the License.
 'use strict';
 
+const debug = require('debug')('couchbackup:restore');
 const { Liner } = require('../includes/liner.js');
 const { Restore } = require('../includes/restoreMappings.js');
 const { BatchingStream, MappingStream, SplittingStream } = require('./transforms.js');
+const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 
-module.exports = function(dbClient, options, readstream, outputWritable) {
+/**
+ * Function for performing a restore.
+ *
+ * @param {object} dbClient - object for connection to source database containing name, service and url
+ * @param {object} options - restore configuration
+ * @param {Readable} readstream - the backup file content
+ * @param {EventEmitter} ee - the user facing EventEmitter
+ * @returns a promise that resolves when the restore is complete or rejects if it errors
+ */
+module.exports = function(dbClient, options, readstream, ee) {
   const restore = new Restore(dbClient);
+  let total = 0; // the total restored
+
+  const output = new Writable({
+    objectMode: true,
+    write: (restoreBatch, encoding, cb) => {
+      debug(' restored ', restoreBatch.documents);
+      total += restoreBatch.documents;
+      try {
+        ee.emit('restored', { ...restoreBatch, total });
+      } finally {
+        cb();
+      }
+    }
+  });
 
   return pipeline(
     readstream, // the backup file
@@ -29,6 +54,8 @@ module.exports = function(dbClient, options, readstream, outputWritable) {
     new BatchingStream(options.bufferSize), // make new arrays of the correct buffer size
     new MappingStream(restore.docsToRestoreBatch), // make a restore batch
     new MappingStream(restore.pendingToRestored, options.parallelism), // do the restore at the desired level of concurrency
-    outputWritable // any output
-  );
+    output // emit restored events
+  ).then(() => {
+    return { total };
+  });
 };

--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -150,7 +150,7 @@ class DuplexPassThrough extends PassThrough {
 
 /**
  * Input: stream of x
- * Output: stream of mappingFunction(x)
+ * Output: stream of x with elements not passing the filter removed
  */
 class FilterStream extends Duplex {
   constructor(filterFunction) {

--- a/test/restoreMappings.js
+++ b/test/restoreMappings.js
@@ -142,7 +142,7 @@ describe('#unit restore mappings', function() {
       // pendingToRestored modifies objects in place, so take a copy otherwise we might impact other tests
       const source = { ...testBatches[0] };
       return new Restore(dbClient).pendingToRestored(source).then((result) => {
-        assert.deepStrictEqual(result, { batch: 0, documents: 3, total: 3 });
+        assert.deepStrictEqual(result, { batch: 0, documents: 3 });
         assert.ok(nock.isDone(), 'The mocks should all be called.');
       });
     });
@@ -152,7 +152,7 @@ describe('#unit restore mappings', function() {
       const source = testBatches.map((batch) => { return { ...batch }; });
       // add two more responses
       mockResponse(2);
-      const expectedOutput = [{ batch: 0, documents: 3, total: 3 }, { batch: 1, documents: 3, total: 6 }, { batch: 2, documents: 3, total: 9 }];
+      const expectedOutput = [{ batch: 0, documents: 3 }, { batch: 1, documents: 3 }, { batch: 2, documents: 3 }];
       const output = [];
       await pipeline(source, new MappingStream(new Restore(dbClient).pendingToRestored), outputAsWritable(output));
       assert.deepStrictEqual(output, expectedOutput);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to modernization, changes will be updated later.
- [x] Completed the PR template below:

## Description

Tidy up the even emitters after the pipeline refactoring.

Fixes i268

## Approach

* Move `finished` events to fire alongside the `callback` at the end of the app.js promise chain.
* Pass the event emitter to backup/restore for the interim events to be emitted (`changes`/`written` and `restored` respectively)
* Keep the running totals in the internal backup/restore functions and return them as the resolved promise value.
* Don't track the total in individual restore batch "chunks" because they can get out of order.

## Schema & API Changes

- Internal changes only.

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because ...

## Monitoring and Logging

- "No change"
