### PR TITLE
refactor: add async all docs generator

### DIFF
--- a/includes/allDocsGenerator.js
+++ b/includes/allDocsGenerator.js
@@ -1,0 +1,53 @@
+// Copyright © 2023 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const debug = require('debug')('couchbackup:alldocsgenerator');
+const { BackupError } = require('./error.js');
+
+/**
+ * Async generator function for paginating _all_docs for shallow backups.
+ *
+ * @param {object} dbClient - object for connection to source database containing name, service and url
+ * @param {object} options - backup configuration
+ * @yields {object} a "done" type backup batch {command: d, batch: #, docs: [{_id: id, ...}, ...]}
+ */
+module.exports = async function * (dbClient, options = {}) {
+  let batch = 0;
+  let lastPage = false;
+  let startKey = null;
+  const opts = { db: dbClient.dbName, limit: options.bufferSize, includeDocs: true };
+  do {
+    if (startKey) opts.startKey = startKey;
+    yield dbClient.service.postAllDocs(opts).then(response => {
+      if (!(response.result && response.result.rows)) {
+        throw new BackupError('AllDocsError', 'Invalid all docs response');
+      }
+      debug(`Got page from start key '${startKey}'`);
+      const docs = response.result.rows;
+      debug(`Received ${docs.length} docs`);
+      lastPage = docs.length < opts.limit;
+      if (docs.length > 0) {
+        const lastKey = docs[docs.length - 1].id;
+        debug(`Received up to key ${lastKey}`);
+        // To avoid double fetching a document solely for the purposes of getting
+        // the next ID to use as a startKey for the next page we instead use the
+        // last ID of the current page and append the lowest unicode sort
+        // character.
+        startKey = `${lastKey}\0`;
+      }
+      return { command: 'd', batch: batch++, docs: docs.map(doc => { return doc.doc; }) };
+    });
+  } while (!lastPage);
+};

--- a/test/allDocsGenerator.js
+++ b/test/allDocsGenerator.js
@@ -1,0 +1,200 @@
+// Copyright © 2023 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it beforeEach */
+'use strict';
+
+const asyncGenerator = require('../includes/allDocsGenerator.js');
+const assert = require('assert');
+const { newClient } = require('../includes/request.js');
+const fs = require('fs');
+const nock = require('nock');
+const { Writable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+
+function allDocsGen(dbUrl, opts) {
+  const db = newClient(dbUrl, opts);
+  // Disable compression to make body assertions easier
+  db.service.setEnableGzipCompression(false);
+  return asyncGenerator(db, opts);
+}
+
+describe('#unit async all docs generator', function() {
+  const dbUrl = 'http://localhost:5984/animaldb';
+
+  beforeEach('Reset nocks', function() {
+    nock.cleanAll();
+  });
+
+  it('should return expected items to writer', async function() {
+    let actualTotal = 0;
+    const output = [];
+    // Query string keys are stringified by Nano
+    const badgerKey = 'badger\0';
+    const kookaburraKey = 'kookaburra\0';
+    const snipeKey = 'snipe\0';
+    let iter = 1;
+
+    const couch = nock(dbUrl)
+      // batch 1
+      .post('/_all_docs', { limit: 3, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_1.json', { 'Content-Type': 'application/json' })
+      // batch 2
+      .post('/_all_docs', { limit: 3, start_key: badgerKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_2.json', { 'Content-Type': 'application/json' })
+      // batch 3
+      .post('/_all_docs', { limit: 3, start_key: kookaburraKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_3.json', { 'Content-Type': 'application/json' })
+      // batch 4
+      .post('/_all_docs', { limit: 3, start_key: snipeKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_4.json', { 'Content-Type': 'application/json' });
+
+    await pipeline(
+      allDocsGen(dbUrl, { parallelism: 1, bufferSize: 3 }),
+      new Writable({
+        objectMode: true,
+        write: (chunk, encoding, callback) => {
+          output.push(chunk);
+          actualTotal += chunk.docs.length;
+          callback();
+        }
+      })
+    );
+
+    for (const [, value] of Object.entries(output)) {
+      for (const [key, actualDoc] of Object.entries(value.docs)) {
+        const expectedDocs = JSON.parse(fs.readFileSync(`./test/fixtures/animaldb_all_docs_${iter}.json`, 'utf8'));
+        assert.deepStrictEqual(actualDoc, expectedDocs.rows[key].doc);
+      }
+      assert.ok(Number.isInteger(value.batch));
+      assert.strictEqual(value.command, 'd');
+      if (value.batch === 3) {
+        assert.strictEqual(value.docs.length, 2); // smaller last batch
+      } else {
+        assert.strictEqual(value.docs.length, 3);
+      }
+      iter++;
+    }
+    assert.strictEqual(actualTotal, 11);
+    assert.ok(couch.isDone());
+  });
+
+  it('should return expected items with transient error', async function() {
+    let actualTotal = 0;
+    const output = [];
+    // Query string keys are stringified by Nano
+    const badgerKey = 'badger\0';
+    const kookaburraKey = 'kookaburra\0';
+    const snipeKey = 'snipe\0';
+    let iter = 1;
+
+    const couch = nock(dbUrl)
+      // batch 1
+      .post('/_all_docs', { limit: 3, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_1.json', { 'Content-Type': 'application/json' })
+      // batch 2
+      .post('/_all_docs', { limit: 3, start_key: badgerKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_2.json', { 'Content-Type': 'application/json' })
+      // batch 3 - transient error
+      .post('/_all_docs', { limit: 3, start_key: kookaburraKey, include_docs: true })
+      .reply(500, { error: 'Internal Server Error' })
+      // batch 3 - retry
+      .post('/_all_docs', { limit: 3, start_key: kookaburraKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_3.json', { 'Content-Type': 'application/json' })
+      // batch 4
+      .post('/_all_docs', { limit: 3, start_key: snipeKey, include_docs: true })
+      .replyWithFile(200, './test/fixtures/animaldb_all_docs_4.json', { 'Content-Type': 'application/json' });
+
+    await pipeline(
+      allDocsGen(dbUrl, { parallelism: 1, bufferSize: 3 }),
+      new Writable({
+        objectMode: true,
+        write: (chunk, encoding, callback) => {
+          output.push(chunk);
+          actualTotal += chunk.docs.length;
+          callback();
+        }
+      })
+    );
+
+    for (const [, value] of Object.entries(output)) {
+      for (const [key, actualDoc] of Object.entries(value.docs)) {
+        const expectedDocs = JSON.parse(fs.readFileSync(`./test/fixtures/animaldb_all_docs_${iter}.json`, 'utf8'));
+        assert.deepStrictEqual(actualDoc, expectedDocs.rows[key].doc);
+      }
+      assert.ok(Number.isInteger(value.batch));
+      assert.strictEqual(value.command, 'd');
+      if (value.batch === 3) {
+        assert.strictEqual(value.docs.length, 2); // smaller last batch
+      } else {
+        assert.strictEqual(value.docs.length, 3);
+      }
+      iter++;
+    }
+    assert.strictEqual(actualTotal, 11);
+    assert.ok(couch.isDone());
+  });
+
+  it('should return expected items with empty page', async function() {
+    let actualTotal = 0;
+    const mockDoc = {
+      _id: 'doc1',
+      _rev: '1-abc',
+      foo: 'bar'
+    };
+    const expected = [{ command: 'd', batch: 0, docs: [mockDoc] }, { command: 'd', batch: 1, docs: [] }];
+    const output = [];
+
+    const couch = nock(dbUrl)
+      // first batch (0)
+      .post('/_all_docs', { limit: 1, include_docs: true })
+      .reply(200, {
+        total_rows: 1,
+        offset: 0,
+        rows: [
+          {
+            id: 'doc1',
+            key: 'doc1',
+            value: {
+              rev: '1-abc'
+            },
+            doc: mockDoc
+          }
+        ]
+      })
+      // second batch (1) (empty)
+      .post('/_all_docs', { limit: 1, start_key: 'doc1\0', include_docs: true })
+      .reply(200, {
+        total_rows: 1,
+        offset: 0,
+        rows: []
+      });
+
+    await pipeline(
+      allDocsGen(dbUrl, { parallelism: 1, bufferSize: 1 }),
+      new Writable({
+        objectMode: true,
+        write: (chunk, encoding, callback) => {
+          output.push(chunk);
+          actualTotal += chunk.docs.length;
+          callback();
+        }
+      })
+    );
+
+    assert.strictEqual(actualTotal, 1);
+    assert.deepStrictEqual(output, expected);
+    assert.ok(couch.isDone());
+  });
+});


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Implement `_all_docs` async generator to be used by shallow backup pipeline in issue 267.
Fixes i271
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
- Implement async generator that yields docs within the `_all_docs` result
- Add some debugging statements
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
- "No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
- "No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
- Add new tests for asserting: 
  - all documents passed through pipeline are expected compared to original test fixture files 
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
- "No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
