### PR TITLE
refactor: remove liner constructor arg

### DIFF
--- a/includes/liner.js
+++ b/includes/liner.js
@@ -17,8 +17,18 @@ const { once } = require('node:events');
 const { createInterface } = require('node:readline');
 const { PassThrough, Transform } = require('node:stream');
 
+/**
+ * A transform stream that transforms a stream to a stream
+ * of line objects using the built-in readLineInterface.
+ * The new stream line objects have the form
+ * {lineNumber: #, line: content}
+ *
+ * Note that it uses the `line` event and not `for await...of`
+ * for performance reasons. See Node Readline module docs for
+ * details.
+ */
 class Liner extends Transform {
-  constructor(withNumbers = false) {
+  constructor() {
     super({ objectMode: true });
     this.lineNumber = 0;
     this.inStream = new PassThrough({ objectMode: true });
@@ -27,7 +37,7 @@ class Liner extends Transform {
       terminal: false
     }).on('line', (line) => {
       this.lineNumber++;
-      this.push(withNumbers ? this.wrapLine(line) : line);
+      this.push(this.wrapLine(line));
     });
     this.readlineInterfaceClosePromise = once(this.readlineInterface, 'close');
   }

--- a/includes/logfilegetbatches.js
+++ b/includes/logfilegetbatches.js
@@ -30,7 +30,7 @@ module.exports = function(log, batches) {
   const logMapper = new LogMapper();
   return [
     fs.createReadStream(log), // log file
-    new Liner(true), // split it into lines
+    new Liner(), // split it into lines
     new MappingStream(logMapper.logLineToBackupBatch), // parse line to a backup batch
     new FilterStream((metadata) => {
       // delete returns true if the key exists, false otherwise

--- a/includes/logfilesummary.js
+++ b/includes/logfilesummary.js
@@ -36,7 +36,7 @@ module.exports = async function(log) {
 
   await pipeline(
     createReadStream(log), // read the log file
-    new Liner(true), // split it into lines
+    new Liner(), // split it into lines
     new MappingStream(logMapper.logLineToMetadata), // parse line to metadata
     new Writable({
       objectMode: true,

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2018 IBM Corp. All rights reserved.
+// Copyright © 2017, 2023 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ module.exports = function(dbClient, options, readstream, ee) {
 
   return pipeline(
     readstream, // the backup file
-    new Liner(true), // line by line
+    new Liner(), // line by line
     new MappingStream(restore.backupLineToDocsArray), // convert line to a docs array
     new SplittingStream(), // break down the arrays to elements
     new BatchingStream(options.bufferSize), // make new arrays of the correct buffer size

--- a/test/backupMappings.js
+++ b/test/backupMappings.js
@@ -57,7 +57,7 @@ describe('#unit backup mappings', function() {
   });
 
   describe('log line mappers', function() {
-    const liner = new Liner(true);
+    const liner = new Liner();
     const logMapper = new LogMapper();
     const makeTestForLogLine = (fn, logLine, expected) => {
       logLine = liner.wrapLine(logLine);
@@ -197,7 +197,7 @@ describe('#unit backup mappings', function() {
       const output = [];
       return pipeline(
         fs.createReadStream('./test/fixtures/test2.log'), // read the log
-        new Liner(true), // break it into lines
+        new Liner(), // break it into lines
         new MappingStream(new LogMapper().logLineToBackupBatch), // map the lines to batches
         new FilterStream((batch) => { return batch.command === 't'; }), // filter to type t batches
         new MappingStream(backup.pendingToFetched), // fetch the batches

--- a/test/liner.js
+++ b/test/liner.js
@@ -48,4 +48,12 @@ describe('#unit liner', function() {
     await pipeline(fs.createReadStream('./test/fixtures/test.log'), liner, destination);
     assert.strictEqual(liner.lineNumber, 10);
   });
+
+  it('should stream line numbers correctly', async function() {
+    const input = Array.from({ length: 10000 }, (_, i) => `A test line with a number ${i}`);
+    const inputLines = input.map(e => `${e}\n`);
+    const expected = input.map((e, i) => { return { lineNumber: i + 1, line: e }; });
+    await pipeline(inputLines, liner, destination);
+    assert.deepStrictEqual(output, expected);
+  });
 });

--- a/test/restoreMappings.js
+++ b/test/restoreMappings.js
@@ -47,7 +47,7 @@ describe('#unit restore mappings', function() {
 
   describe('backupLineToDocsArray', function() {
     // Use a liner to make the line objects with line numbers
-    const liner = new Liner(true);
+    const liner = new Liner();
 
     // The class under test
     const restore = new Restore(null);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`
- [x] Completed the PR template below:

## Description

refactor: remove liner constructor arg

Fixes part of i312

## Approach

All the places using `Liner` are now expecting the `{lineNumber: #, line: content}` form and not raw lines so we can remove the constructor arg.

## Schema & API Changes

- I"No change"

## Security and Privacy

- "No change"

## Testing

- Added a new test for checking the lineNumber output on each line.
- Modified existing tests that no longer need to specify the boolean.

## Monitoring and Logging

- "No change"
