### PR TITLE
fix: use bufferSize for seqInterval

### DIFF
--- a/includes/spoolchanges.js
+++ b/includes/spoolchanges.js
@@ -28,7 +28,7 @@ const { ChangesFollower } = require('@ibm-cloud/cloudant');
  * @param {number} bufferSize - the number of changes per batch/log line
  * @param {number} tolerance - changes follower error tolerance
  */
-module.exports = function(dbClient, log, bufferSize, tolerance = 600000) {
+module.exports = function(dbClient, log, bufferSize = 500, tolerance = 600000) {
   let lastSeq;
   let batch = 0;
   let totalBuffer = 0;
@@ -73,7 +73,7 @@ module.exports = function(dbClient, log, bufferSize, tolerance = 600000) {
 
   const changesParams = {
     db: dbClient.dbName,
-    seqInterval: 10000
+    seqInterval: bufferSize
   };
 
   const changesFollower = new ChangesFollower(dbClient.service, changesParams, tolerance);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`
- [x] Completed the PR template below:

## Description

fix: use bufferSize for seqInterval

Fixes part of i312

## Approach

Adjust the `seqInterval` to match the `bufferSize` - this should mean we get at least one seq ID per batch we backup (unless the database is very small i.e. smaller than one batch).

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because code path is covered by existing tests, changing the seqInterval does not impact any other behaviors at present.

## Monitoring and Logging

- `:changes_complete` log entries are more likely to have a sequence ID.
