### PR TITLE
fix: additional resume options validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-13T15:03:52Z",
+  "generated_at": "2023-12-19T15:06:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -120,7 +120,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -128,7 +128,7 @@
         "hashed_secret": "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 166,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/app.js
+++ b/app.js
@@ -174,6 +174,10 @@ async function validateLogOnResume(opts) {
     } else if (!logFileExists) {
       throw new BackupError('LogDoesNotExist', 'To resume a backup, the log file must exist');
     }
+    if (opts.bufferSize) {
+      // Warn that the bufferSize is already fixed
+      console.warn('WARNING: the original backup "bufferSize" applies when resmuming a backup.');
+    }
   } else {
     // Not resuming
     if (logFileExists) {

--- a/includes/error.js
+++ b/includes/error.js
@@ -24,6 +24,7 @@ const codes = {
   NoLogFileName: 20,
   LogDoesNotExist: 21,
   IncompleteChangesInLogFile: 22,
+  LogFileExists: 23,
   SpoolChangesError: 30,
   HTTPFatalError: 40,
   BulkGetError: 50

--- a/test/app.js
+++ b/test/app.js
@@ -107,7 +107,7 @@ describe('#unit Validate arguments', function() {
     return validateArgs(goodUrl, { log: true }, assertErrorMessage('Invalid log option, must be type string'));
   });
   it('returns no error for valid log type', async function() {
-    return validateArgs(goodUrl, { log: 'log.txt' }, assertNoValidationError());
+    return validateArgs(goodUrl, { log: './test/fixtures/test.log', resume: true }, assertNoValidationError());
   });
   it('returns error for invalid mode type', async function() {
     return validateArgs(goodUrl, { mode: true }, assertErrorMessage('Invalid mode option, must be either "full" or "shallow"'));
@@ -159,6 +159,12 @@ describe('#unit Validate arguments', function() {
   });
   it('returns error for key and URL credentials supplied', async function() {
     return validateArgs('https://a:b@example.com/db', { iamApiKey: 'abc123' }, assertErrorMessage('URL user information must not be supplied when using IAM API key.'));
+  });
+  it('returns error for existing log file without resume', async function() {
+    return validateArgs(goodUrl, { log: './test/fixtures/test.log' }, {
+      name: 'LogFileExists',
+      message: 'The log file ./test/fixtures/test.log exists. Use the resume option if you want to resume a backup from an existing log file.'
+    });
   });
   it('warns for log arg in shallow mode', async function() {
     captureStderr();


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`
- [x] Completed the PR template below:

## Description

Add some additional options validation for the `resume` cases.

Fixes part of i312.

## Approach

* Add new `LogFileExists` error (code 23).
* Rework `validateLogOnResume` function to split into 3 parts (no options, resuming and not resuming) with additional checks in the latter 2 parts relating to the log file.
* Add a bufferSize warning line to `validateLogOnResume`.

## Schema & API Changes

- Backup error thrown if a specified log file exists and it is a new backup.

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - assert the buffer size warning is printed when using `resume` and `bufferSize` options.
    - assert the `LogFileExists` error is thrown when not using `resume` and specifying an existing log file.

## Monitoring and Logging

-  Outputs a warning if resuming and specifying `bufferSize`.
