### PR TITLE
fix: additional resume options validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-13T15:03:52Z",
+  "generated_at": "2023-12-19T15:06:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -120,7 +120,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -128,7 +128,7 @@
         "hashed_secret": "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 166,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/app.js
+++ b/app.js
@@ -173,6 +173,10 @@ async function validateLogOnResume(opts) {
     } else if (!logFileExists) {
       throw new BackupError('LogDoesNotExist', 'To resume a backup, the log file must exist');
     }
+    if (opts.bufferSize) {
+      // Warn that the bufferSize is already fixed
+      console.warn('WARNING: the original backup "bufferSize" applies when resuming a backup.');
+    }
   } else {
     // Not resuming
     if (logFileExists) {

--- a/app.js
+++ b/app.js
@@ -159,15 +159,26 @@ async function shallowModeWarnings(opts) {
  */
 
 async function validateLogOnResume(opts) {
-  if (!opts || !opts.resume) {
+  const logFileExists = opts && opts.log && fs.existsSync(opts.log);
+  if (!opts || opts.mode === 'shallow') {
+    // No opts specified, defaults will be populated.
+    // In shallow mode log/resume are irrelevant and we'll have warned already.
     return true;
-  }
-  if (!opts.log) {
-    // This is the second place we check for the presence of the log option in conjunction with resume
-    // It has to be here for the API case
-    throw new BackupError('NoLogFileName', 'To resume a backup, a log file must be specified');
-  } else if (!fs.existsSync(opts.log)) {
-    throw new BackupError('LogDoesNotExist', 'To resume a backup, the log file must exist');
+  } else if (opts.resume) {
+    // Expecting to resume
+    if (!opts.log) {
+      // This is the second place we check for the presence of the log option in conjunction with resume
+      // It has to be here for the API case
+      throw new BackupError('NoLogFileName', 'To resume a backup, a log file must be specified');
+    } else if (!logFileExists) {
+      throw new BackupError('LogDoesNotExist', 'To resume a backup, the log file must exist');
+    }
+  } else {
+    // Not resuming
+    if (logFileExists) {
+      throw new BackupError('LogFileExists', `The log file ${opts.log} exists. ` +
+      'Use the resume option if you want to resume a backup from an existing log file.');
+    }
   }
   return true;
 }
@@ -177,16 +188,22 @@ async function validateLogOnResume(opts) {
  *
  * @param {string} url - URL of database.
  * @param {object} opts - Options.
+ * @param {boolean} backup - true for backup, false for restore
  * @returns Boolean true if all checks are passing.
  */
-async function validateArgs(url, opts) {
+async function validateArgs(url, opts, isBackup = true) {
   const isIAM = opts && typeof opts.iamApiKey === 'string';
-  return Promise.all([
+  const validations = [
     validateURL(url, isIAM),
-    validateOptions(opts),
-    shallowModeWarnings(opts),
-    validateLogOnResume(opts)
-  ]);
+    validateOptions(opts)
+  ];
+  if (isBackup) {
+    validations.push(
+      shallowModeWarnings(opts),
+      validateLogOnResume(opts)
+    );
+  }
+  return Promise.all(validations);
 }
 
 /**
@@ -329,7 +346,7 @@ module.exports = {
 
     const ee = new events.EventEmitter();
 
-    validateArgs(targetUrl, opts)
+    validateArgs(targetUrl, opts, false)
       // Set up the DB client
       .then(() => {
         opts = Object.assign({}, defaults(), opts);

--- a/includes/error.js
+++ b/includes/error.js
@@ -24,6 +24,7 @@ const codes = {
   NoLogFileName: 20,
   LogDoesNotExist: 21,
   IncompleteChangesInLogFile: 22,
+  LogFileExists: 23,
   SpoolChangesError: 30,
   HTTPFatalError: 40,
   BulkGetError: 50

--- a/test/app.js
+++ b/test/app.js
@@ -107,7 +107,7 @@ describe('#unit Validate arguments', function() {
     return validateArgs(goodUrl, { log: true }, assertErrorMessage('Invalid log option, must be type string'));
   });
   it('returns no error for valid log type', async function() {
-    return validateArgs(goodUrl, { log: 'log.txt' }, assertNoValidationError());
+    return validateArgs(goodUrl, { log: './test/fixtures/test.log', resume: true }, assertNoValidationError());
   });
   it('returns error for invalid mode type', async function() {
     return validateArgs(goodUrl, { mode: true }, assertErrorMessage('Invalid mode option, must be either "full" or "shallow"'));
@@ -159,6 +159,12 @@ describe('#unit Validate arguments', function() {
   });
   it('returns error for key and URL credentials supplied', async function() {
     return validateArgs('https://a:b@example.com/db', { iamApiKey: 'abc123' }, assertErrorMessage('URL user information must not be supplied when using IAM API key.'));
+  });
+  it('returns error for existing log file without resume', async function() {
+    return validateArgs(goodUrl, { log: './test/fixtures/test.log' }, {
+      name: 'LogFileExists',
+      message: 'The log file ./test/fixtures/test.log exists. Use the resume option if you want to resume a backup from an existing log file.'
+    });
   });
   it('warns for log arg in shallow mode', async function() {
     captureStderr();

--- a/test/app.js
+++ b/test/app.js
@@ -37,19 +37,24 @@ const validateArgs = async function(url, opts, errorValidationForAssertRejects) 
   return assert.rejects(backupPromise(url, nullStream, opts), errorValidationForAssertRejects);
 };
 
-const validateShallowModeArgs = async function(url, opts, msg) {
-  // We pass assertNoValidationError because for these shallow opts
+const validateStdErrWarning = async function(url, opts, msg) {
+  captureStderr();
+  // We pass assertNoValidationError because for these opts
   // we are expecting only a stderr warning
   return validateArgs(url, opts, assertNoValidationError()).then(() => {
     // Assert the warning message was in stderr
-    assert(capturedStderr.indexOf(msg) > -1, 'Log warning message was not present');
+    assert.ok(capturedStderr, 'There should be captured stderr');
+    assert.ok(capturedStderr.indexOf(msg) > -1, 'Log warning message was not present');
+  }).finally(() => {
+    releaseStderr();
   });
 };
 
 const stderrWriteFun = process.stderr.write;
-let capturedStderr;
+let capturedStderr = '';
 
 function captureStderr() {
+  // Redefine the stderr write to capture
   process.stderr.write = function(string, encoding, fd) {
     capturedStderr += string;
   };
@@ -167,27 +172,19 @@ describe('#unit Validate arguments', function() {
     });
   });
   it('warns for log arg in shallow mode', async function() {
-    captureStderr();
-    return validateShallowModeArgs(goodUrl, { mode: 'shallow', log: 'test' },
-      'the options "log" and "resume" are invalid when using shallow mode.').finally(
-      () => {
-        releaseStderr();
-      });
+    return validateStdErrWarning(goodUrl, { mode: 'shallow', log: 'test' },
+      'the options "log" and "resume" are invalid when using shallow mode.');
   });
   it('warns for resume arg in shallow mode', async function() {
-    captureStderr();
-    return validateShallowModeArgs(goodUrl, { mode: 'shallow', log: 'test', resume: true },
-      'the options "log" and "resume" are invalid when using shallow mode.').finally(
-      () => {
-        releaseStderr();
-      });
+    return validateStdErrWarning(goodUrl, { mode: 'shallow', log: 'test', resume: true },
+      'the options "log" and "resume" are invalid when using shallow mode.');
   });
   it('warns for parallelism arg in shallow mode', async function() {
-    captureStderr();
-    return validateShallowModeArgs(goodUrl, { mode: 'shallow', parallelism: 10 },
-      'the option "parallelism" has no effect when using shallow mode.').finally(
-      () => {
-        releaseStderr();
-      });
+    return validateStdErrWarning(goodUrl, { mode: 'shallow', parallelism: 10 },
+      'the option "parallelism" has no effect when using shallow mode.');
+  });
+  it('warns for buffer size arg when resuming', async function() {
+    return validateStdErrWarning(goodUrl, { log: './test/fixtures/test.log', resume: true, bufferSize: 100 },
+      'the original backup "bufferSize" applies when resuming a backup.');
   });
 });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`
- [x] Completed the PR template below:

## Description

Add some additional options validation for the `resume` cases.

Fixes part of i312.

## Approach

* Add new `LogFileExists` error (code 23).
* Rework `validateLogOnResume` function to split into 3 parts (no options, resuming and not resuming) with additional checks in the latter 2 parts relating to the log file.
* Add a bufferSize warning line to `validateLogOnResume`.

## Schema & API Changes

- Backup error thrown if a specified log file exists and it is a new backup.

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - assert the buffer size warning is printed when using `resume` and `bufferSize` options.
    - assert the `LogFileExists` error is thrown when not using `resume` and specifying an existing log file.
- Modifed existing tests to avoid creating a log file in advance of the backup because that is now an error condition. Instead we have a watcher on the folder and then start the log file tail after the log file appears.

## Monitoring and Logging

-  Outputs a warning if resuming and specifying `bufferSize`.
