### PR TITLE
[WIP] Prepare 2.9.16 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.9.16 (2024-01-10)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.2`.
+
 # 2.9.15 (2023-12-04)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.0`.
 - [NOTE] Updated Node.js version requirement statement for LTS 18 and 20.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.16-SNAPSHOT",
+  "version": "2.9.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.16-SNAPSHOT",
+      "version": "2.9.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.16-SNAPSHOT",
+  "version": "2.9.16",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": "https://github.com/IBM/couchbackup.git",


### PR DESCRIPTION
This is a WIP PR during couchbackup-tests pipeline is running on the current main.

# Proposed 2.9.16 release
## Changes
### 2.9.16 (2024-01-10)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.2`.