### PR TITLE
ci: increase CPU request to 1 and disable concurrent builds

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-23T11:02:43Z",
+  "generated_at": "2024-01-11T17:39:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -214,7 +214,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ def agentYaml() {
     |      resources:
     |        requests:
     |          memory: "2Gi"
-    |          cpu: "650m"
+    |          cpu: "1"
     |        limits:
     |          memory: "4Gi"
     |          cpu: "4"
@@ -164,6 +164,9 @@ pipeline {
     kubernetes {
       yaml "${agentYaml()}"
     }
+  }
+  options {
+    disableConcurrentBuilds()
   }
   stages {
     stage('Build') {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

The fatal error unit tests failed right before the merge of https://github.com/IBM/couchbackup/pull/662.
This most likely happened when our kube CI resources were strained and being throttled .  Increasing the CPU request to 1 and disabling concurrent builds should hopefully allow for enough resources so that the test suite doesn't time out.

fixes i316
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
