### PR TITLE
feat: add time to restore output

### DIFF
--- a/bin/couchrestore.bin.js
+++ b/bin/couchrestore.bin.js
@@ -49,7 +49,7 @@ try {
     opts,
     error.terminationCallback
   ).on('restored', function(obj) {
-    restoreBatchDebug('restored', obj.total);
+    restoreBatchDebug('Restored batch ID:', obj.batch, 'Total document revisions restored:', obj.total, 'Time:', obj.time);
   }).on('error', function(e) {
     restoreDebug('ERROR', e);
   }).on('finished', function(obj) {

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -31,6 +31,7 @@ const { pipeline } = require('node:stream/promises');
  */
 module.exports = function(dbClient, options, readstream, ee) {
   const restore = new Restore(dbClient);
+  const start = new Date().getTime(); // restore start time
   let total = 0; // the total restored
 
   const output = new Writable({
@@ -38,8 +39,9 @@ module.exports = function(dbClient, options, readstream, ee) {
     write: (restoreBatch, encoding, cb) => {
       debug(' restored ', restoreBatch.documents);
       total += restoreBatch.documents;
+      const totalRunningTimeSec = (new Date().getTime() - start) / 1000;
       try {
-        ee.emit('restored', { ...restoreBatch, total });
+        ee.emit('restored', { ...restoreBatch, total, time: totalRunningTimeSec });
       } finally {
         cb();
       }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - output format change
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

Match restore output to what is produced by backup.

## Approach

Backup tracks the total time taken for a backup and emits it as part of the `written` progress event emitted after each batch.
Restore did not have equivalent functionality, but it is quite useful for making quick checks on performance impact of the `modernization` changes.
The output from the `restored` event  was also only the total number of revisions, but did not indicate the batch ID like backup does.

The change adds the time taken to the emitted `restored` event and changes the CLI output format for `couchrestore` to match that for backup e.g.
` couchbackup:restore:batch Restored batch ID: 0 Total document revisions restored: 1 Time: 0.029`


## Schema & API Changes

- Non-breaking change, adds `time` property to `restored` event object.

## Security and Privacy

- "No change"

## Testing

- No new tests because it is a change to output formatting. The change has been observed to function as expected manually.

## Monitoring and Logging

- Change to output format of progress statements during restore.
