### PR TITLE
fix: batching transform back-pressure

### DIFF
--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -202,7 +202,7 @@ class DelegateWritable extends Writable {
  */
 class DuplexPassThrough extends PassThrough {
   constructor(opts) {
-    super({ ...opts, objectMode: true });
+    super({ objectMode: true, readableHighWaterMark: 0, writableHighWaterMark: 0, ...opts });
   }
 
   // The destroy call on this PassThrough stream


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`, changes will be udpated later.
- [x] Completed the PR template below:

## Description

Fix batching back-pressure and reduce double-buffering on mapping streams.
Part of i330.

## Approach

* `fix: batching transform back-pressure`
    * Check the return value of the `Transform` `push` call to see if there is downstream pressure.
    * If there is, delay the `callback` from the `_transform` to pass that pressure upstream.
    * Override the `_read` method in the batching `Transform` implementation to allow calling the delayed callback when the downstream calls `_read` again (i.e. it is ready to receive more data).
    * Minimize the buffering in the batching transform by reducing the highWaterMarks
* `fix: minimize buffering on map passthroughs`
    * The `PassThrough` used in the mapping transforms would default to a buffer size of 16 objects, this could be very large batches. In practice there is no need for this stream to buffer at all instead it can directly pass from the writable side of the duplex to the buffer in the mapping operation. This is achieved by setting the highWaterMarks to `0`. They are set separately to allow for over-riding one or the other by passing `opts` (if a single `highWaterMark` is set it applies to both readable and writable regardless of their indvidual settings).

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because functionality is tested by existing tests. (This is in response to regressions in the large test suite).

## Monitoring and Logging

- Added some additional logging in the batching transform.
