### PR TITLE
fix: large test regressions for back-pressure and memory footprint

### DIFF
--- a/includes/restore.js
+++ b/includes/restore.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2023 IBM Corp. All rights reserved.
+// Copyright © 2017, 2024 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 const debug = require('debug')('couchbackup:restore');
 const { Liner } = require('../includes/liner.js');
 const { Restore } = require('../includes/restoreMappings.js');
-const { BatchingStream, MappingStream, SplittingStream } = require('./transforms.js');
+const { BatchingStream, MappingStream } = require('./transforms.js');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 
@@ -52,8 +52,7 @@ module.exports = function(dbClient, options, readstream, ee) {
     readstream, // the backup file
     new Liner(), // line by line
     new MappingStream(restore.backupLineToDocsArray), // convert line to a docs array
-    new SplittingStream(), // break down the arrays to elements
-    new BatchingStream(options.bufferSize), // make new arrays of the correct buffer size
+    new BatchingStream(options.bufferSize, true), // make new arrays of the correct buffer size
     new MappingStream(restore.docsToRestoreBatch), // make a restore batch
     new MappingStream(restore.pendingToRestored, options.parallelism), // do the restore at the desired level of concurrency
     output // emit restored events

--- a/includes/transforms.js
+++ b/includes/transforms.js
@@ -130,7 +130,7 @@ class DelegateWritable extends Writable {
  */
 class DuplexPassThrough extends PassThrough {
   constructor(opts) {
-    super({ ...opts, objectMode: true });
+    super({ objectMode: true, readableHighWaterMark: 0, writableHighWaterMark: 0, ...opts });
   }
 
   // The destroy call on this PassThrough stream
@@ -155,7 +155,7 @@ class DuplexPassThrough extends PassThrough {
 class FilterStream extends Duplex {
   constructor(filterFunction) {
     const inputStream = new DuplexPassThrough();
-    return Duplex.from({ readable: inputStream.filter(filterFunction), writable: inputStream });
+    return Duplex.from({ readable: inputStream.filter(filterFunction, { concurrency: 1, highWaterMark: 0 }), writable: inputStream });
   }
 }
 
@@ -164,11 +164,9 @@ class FilterStream extends Duplex {
  * Output: stream of mappingFunction(x)
  */
 class MappingStream extends Duplex {
-  constructor(mappingFunction, concurrency = 1) {
-    const inputStream = new DuplexPassThrough({
-      highWaterMark: concurrency * 2
-    });
-    return Duplex.from({ readable: inputStream.map(mappingFunction, { concurrency }), writable: inputStream });
+  constructor(mappingFunction, concurrency = 1, highWaterMark = 0) {
+    const inputStream = new DuplexPassThrough();
+    return Duplex.from({ readable: inputStream.map(mappingFunction, { concurrency, highWaterMark: 0 }), writable: inputStream });
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - merging to `modernization`, changes will be udpated later.
- [x] Completed the PR template below:

## Description

* Fix batching back-pressure
* Replace `SplittingStream`->`BatchingStream` with new `BatchingStream` with re-batching.
* Reduce double-buffering on mapping streams.

Part of i330.

## Approach

* `fix: batching Duplex with back-pressure`
    * Re-implement the `BatchingStream` as a `Duplex` instead of a `Transform` to allow finer control over read/write back-pressure.
    * Add `rebatch` flag to `BatchingStream` that switches from accepting single elements to accepting arrays and spread the arrays when pushing available elements.
    * See code comments for full details.
* `fix: minimize buffering on map passthroughs`
    * The `DuplexPassThrough` used in the mapping transforms would default to a buffer size of 16 objects, this could be very large batches. In practice there is no need for this stream to buffer at all instead it can directly pass from the writable side of the duplex to the buffer in the mapping operation. This is achieved by setting the highWaterMarks to `0`. They are set separately to allow for over-riding one or the other by passing `opts` (if a single `highWaterMark` is set it applies to both readable and writable regardless of their indvidual settings).
    * Also set the `highWaterMark` for the `map` and `filter` `Readable`s to `0` to reduce memory footprint.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Most functionality is tested by existing tests. (This is in response to regressions in the large test suite).
- Modified the `SplittingStream` tests to use the new `BatchingStream` with `rebatch` and an output size of 1. Also added nnew tests for rebatching to other sizes.

## Monitoring and Logging

- Added additional logging in the batching transform.
