### PR TITLE
docs: clean up s3 examples

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-01-11T17:39:14Z",
+  "generated_at": "2024-01-25T12:14:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -95,12 +95,30 @@
         "verified_result": null
       }
     ],
+    "examples/README.md": [
+      {
+        "hashed_secret": "43bce7a87dd0e4b8c09b44173613bc95ba77d714",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "745d0b2380e21353d526db47a87158f2065563ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "examples/s3-backup-file.js": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 41,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -110,7 +128,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 38,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,9 @@
 # CouchBackup Examples
 
-This folder contains Node.js scripts which use the `couchbackup` library.
+This folder contains example Node.js scripts which use the `couchbackup` library.
 
-Use `npm install ../; npm install` in this folder to install the script
-dependencies. This uses the checked out copy of couchbackup to ensure
-everything is in sync.
-
-Run a script without arguments to receive help.
+These scripts are for inspiration and demonstration.
+They are not a supported part of couchbackup and should not be considered production ready.
 
 ## Current examples
 
@@ -17,3 +14,78 @@ Run a script without arguments to receive help.
 2. `s3-backup-stream.js` -- backup a database to an S3-API compatible store
     by streaming the backup data directly from CouchDB or Cloudant into
     an object.
+
+#### Prerequisites
+
+##### Install the dependencies
+
+Use `npm install` in this folder to install the script
+dependencies.
+Note: this uses the latest release of couchbackup, not the
+checked out out version.
+
+##### AWS SDK configuration
+
+The scripts expect AWS ini files:
+* shared credentials file `~/.aws/credentials` or target file from `AWS_SHARED_CREDENTIALS_FILE` environment variable
+* shared configuration file `~/.aws/config` or target file from `AWS_CONFIG_FILE` environment variable
+
+###### IBM COS
+
+When using IBM Cloud Object Storage create a service credential with the `Include HMAC Credential` option enabled.
+The `access_key_id` and `secret_access_key` from the `cos_hmac_keys` entry in the generated credential are
+the ones required to make an AWS credentials file e.g.
+```ini
+[default]
+aws_access_key_id=paste access_key_id here
+aws_secret_access_key=paste secret_access_key here
+```
+
+Run the scripts with the `--s3url` option pointing to your COS instance s3 endpoint.
+The AWS SDK requires a region to initialize so ensure the config file has one named e.g.
+```ini
+[default]
+region=eu-west-2
+```
+
+#### Usage
+
+Run a script without arguments to receive help e.g.
+
+`node s3-backup-file.js`
+
+The source database and destination bucket are required options.
+The minimum needed to run the scripts are thus:
+
+`node s3-backup-stream.js -s 'https://dbser:dbpass@host.example/exampledb' -b 'examplebucket'`
+
+The object created in the bucket for the backup file will be
+named according to a prefix (default `couchbackup`), DB name and timestamp e.g.
+
+`couchbackup-exampledb-2024-01-25T09:45:11.730Z`
+
+#### Progress and debug
+
+To see detailed progress of the backup and upload or additional debug information
+use the `DEBUG` environment variable with label `s3-backup` e.g.
+
+`DEBUG='s3-backup' node s3-backup-stream.js -s 'https://dbser:dbpass@host.example/exampledb' -b 'couchbackup' --s3url 'https://s3.eu-gb.cloud-object-storage.appdomain.cloud'`
+
+```
+  s3-backup Creating a new backup of https://host.example/exampledb at couchbackup/couchbackup-exampledb-2024-01-25T09:45:11.730Z... +0ms
+  s3-backup Setting up S3 upload to couchbackup/couchbackup-exampledb-2024-01-25T09:45:11.730Z +686ms
+  s3-backup Starting streaming data from https://host.example/exampledb +2ms
+  s3-backup Couchbackup changes batch:  0 +136ms
+  s3-backup Fetched batch: 0 Total document revisions written: 15 Time: 0.067 +34ms
+  s3-backup couchbackup download from https://host.example/exampledb complete; backed up 15 +2ms
+  s3-backup S3 upload progress: {"loaded":6879,"total":6879,"part":1,"Key":"couchbackup-exampledb-2024-01-25T09:45:11.730Z","Bucket":"couchbackup"} +623ms
+  s3-backup S3 upload done +1ms
+  s3-backup Upload succeeded +0ms
+  s3-backup done. +0ms
+```
+
+#### Known issues
+
+The S3 SDK does not appear to apply back-pressure to a Node `stream.Readable`. As such in environments
+where the upload speed to S3 is significantly slower than either the speed of downloading from the database
+or reading the backup file then the scripts may fail.

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,31 +1,15 @@
 {
   "name": "couchbackup-examples",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Examples of using CouchBackup as a library",
   "dependencies": {
-    "aws-sdk": "^2.39.0",
-    "tmp": "^0.0.31",
-    "verror": "^1.10.0",
-    "yargs": "^7.0.2"
+    "@cloudant/couchbackup": "^2.9.16",
+    "@aws-sdk/client-s3": "^3.499.0",
+    "@aws-sdk/credential-providers": "^3.499.0",
+    "@aws-sdk/lib-storage": "^3.499.0",
+    "verror": "^1.10.1",
+    "yargs": "^17.7.2"
   },
-  "devDependencies": {
-    "eslint": "^6.5.1",
-    "eslint-plugin-standard": "^3.0.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-node": "^4.2.2",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^7.0.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-config-semistandard": "^11.0.0",
-    "jsdoc": "^3.4.3",
-    "mocha": "^3.2.0",
-    "cloudant": "^1.7.1",
-    "uuid": "^3.0.1"
-  },
-  "scripts": {
-    "test": "eslint --ignore-path .gitignore . && mocha"
-  },
-  "author": "",
   "license": "Apache-2.0"
 }
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Clean up the S3 example scripts.

Fixes #694 

## Approach

* Extende the `examples/README.md` with additional instructions and details.
* Clean up dependencies
    * Add dependency on latest `2.x` `@cloudant/couchbackup` (docs said it was using the repo version, but the code had been changed when the package became scoped that it wasn't actually using the checked out version - better to just use latest compatibile shipped version).
    * Use latest modular v3 `aws-sdk` for `client-s3`, `credential-providers`, `lib-storage`
    * Remove dependency on `tmp`
    * Remove unusued `dev-dependencies`
* Clean up `package.json` to update version to `0.0.2` and remove unused script command.
* Update script code for latest `aws-sdk` changes.
* Add `couchbackup` event handlers for additional progress/debug.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A example code, but I tested it manually.

## Monitoring and Logging

- "No change"
