### PR TITLE
test: destroy unused stream

### DIFF
--- a/test/ci_error.js
+++ b/test/ci_error.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2023 IBM Corp. All rights reserved.
+// Copyright © 2017, 2024 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ describe('Write error tests', function() {
     // try to do backup and check err was set in callback
     return assert.rejects(u.testBackup(params, 'animaldb', backupStream), { name: 'TypeError', message: 'dest.write is not a function' })
       .finally(async() => {
+        // Destroy the read stream we didn't use
+        backupStream.destroy();
         // cleanup temp dir
         await rm(dirname, { recursive: true });
       });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test only
- [x] Completed the PR template below:

## Description

Destory unused stream to avoid deprecated GC file cleanup.

Fixes: i338

## Approach

The write error tests use a read stream as a backup destination to test errors of that type. As such the read stream created by the test is never read to the end and thus not automatically cleaned up. The GC file cleanup happens eventually, but produces a deprecation warning and will in future cause tests to error.

To avoid this we call `destroy` on the stream in the test `finally`.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests as described above.

## Monitoring and Logging

- "No change"
