### PR TITLE
test: do dbcompare batch wise to reduce overhead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "6.1.1",
         "http-proxy": "1.18.1",
-        "lodash": "4.17.21",
         "mocha": "10.2.0",
         "nock": "13.5.1",
         "tail": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "mocha": "10.2.0",
     "nock": "13.5.1",
     "tail": "2.2.6",
-    "uuid": "9.0.1",
-    "lodash": "4.17.21"
+    "uuid": "9.0.1"
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",

--- a/test/compare.js
+++ b/test/compare.js
@@ -1,4 +1,4 @@
-// Copyright © 2023 IBM Corp. All rights reserved.
+// Copyright © 2023, 2024 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,87 +14,92 @@
 
 'use strict';
 
-const chunk = require('lodash/chunk');
-const difference = require('lodash/difference');
-const forOwn = require('lodash/forOwn');
-const isEmpty = require('lodash/isEmpty');
-const union = require('lodash/union');
+const assert = require('node:assert');
 const client = require('./hooks.js').sharedClient;
 
+/**
+ * Compare 2 databases to check the contents match.
+ * Since all docs is ordered the comparison can be
+ * done 1 batch at a time to reduce the overhead.
+ *
+ * Batches are collected from all docs of each DB
+ * in parallel before being compared for equality.
+ *
+ * If the batches are equal, then the leaf revisions
+ * are fetched in parallel and compared.
+ *
+ * @param {*} database1 name of the "expected" database (i.e. the source)
+ * @param {*} database2 name of the "actual" database (i.e. the target)
+ * @returns Promise resolving to true if the contents match or rejecting with an assertion error
+ */
 const compare = async function(database1, database2) {
-  // check docs same in both dbs
-  const allDocs1 = await getAllDocs(client, database1);
-  const allDocs2 = await getAllDocs(client, database2);
-
-  const onlyInDb1 = (difference(allDocs1, allDocs2));
-  const onlyInDb2 = (difference(allDocs2, allDocs1));
-
-  let databasesSame = isEmpty(onlyInDb1) && isEmpty(onlyInDb2);
-
-  if (!databasesSame) {
-    console.log(onlyInDb1.length + ' documents only in db 1.');
-    console.log('Document IDs only in db 1: ' + onlyInDb1);
-    console.log(onlyInDb2.length + ' documents only in db 2.');
-    console.log('Document IDs only in db 2: ' + onlyInDb2);
-  }
-
-  // check revs same in docs common to both dbs
-  const partitionSize = 500;
-  const batches = chunk(union(allDocs1, allDocs2), partitionSize);
-
-  const missingRevsInDb2 = await getMissingRevs(client, database1, database2, batches);
-  const missingRevsInDb1 = await getMissingRevs(client, database2, database1, batches);
-
-  databasesSame = databasesSame && isEmpty(missingRevsInDb1) && isEmpty(missingRevsInDb2);
-
-  if (!databasesSame) {
-    console.log('Missing revs in db 1:' + JSON.stringify(missingRevsInDb1));
-    console.log('Missing revs in db 2:' + JSON.stringify(missingRevsInDb2));
-  }
-
-  return databasesSame;
-};
-
-const getMissingRevs = async(client, databaseName1, databaseName2, batcheses) => {
-  const fakeRevisionId = '9999-a';
-
-  const missing = {};
-
-  // look in db1 - use a fake revision ID to fetch all leaf revisions
-
-  for (const batches of batcheses) {
-    const documentRevisions = {};
-    batches.forEach(id => (documentRevisions[id] = [fakeRevisionId]));
-
-    const result1 = await client.postRevsDiff({ db: databaseName1, documentRevisions });
-    const revsDiffRequestDb2 = {};
-    forOwn(result1.result, (v, k) => (revsDiffRequestDb2[k] = v.possible_ancestors));
-    // look in db2
-    const result2 = await client.postRevsDiff({ db: databaseName2, documentRevisions: revsDiffRequestDb2 });
-    forOwn(result2.result, (v, k) => {
-      if ('missing' in v) {
-        missing[k] = v.missing;
-      }
-    });
-  }
-  return missing;
-};
-
-const getAllDocs = async function(client, database) {
-  let allDocIds = [];
+  const dbInfoResponses = await Promise.all([client.getDatabaseInformation({ db: database1 }), client.getDatabaseInformation({ db: database2 })]);
+  const db1DocCount = dbInfoResponses[0].result.doc_count;
+  const db1DocDelCount = dbInfoResponses[0].result.doc_del_count;
+  const db2DocCount = dbInfoResponses[1].result.doc_count;
+  const db2DocDelCount = dbInfoResponses[1].result.doc_del_count;
+  // Assert the doc counts match
+  assert.strictEqual(db2DocCount, db1DocCount);
+  assert.strictEqual(db2DocDelCount, db1DocDelCount);
   const limit = 2000;
   let startKey = '\u0000';
+  let count = 0;
   do {
-    const pageOfDocIds = (await client.postAllDocs({ db: database, startKey, limit })).result.rows.map(r => r.id);
-    allDocIds = allDocIds.concat(pageOfDocIds);
-    if (pageOfDocIds.length < limit) {
-      startKey = null;
-    } else {
-      startKey = pageOfDocIds[limit - 1] + '\u0000';
+    const allDocsOpts = { startKey, limit };
+    try {
+      // Fetch batches in parallel from db1 and db2
+      await Promise.all([client.postAllDocs({ db: database1, ...allDocsOpts }), client.postAllDocs({ db: database2, ...allDocsOpts })])
+        .then(results => {
+          const db1Rows = results[0].result.rows;
+          const db2Rows = results[1].result.rows;
+          // Asserts that the IDs and winning revs match
+          assert.deepStrictEqual(db2Rows, db1Rows);
+          // extract the IDs (we use only one db because we already know the IDs are equal)
+          return resultRowsToIds(db1Rows);
+        })
+        .then(async docIDs => {
+          // Post the id/fake rev list to revs diff to get all leaf revisions
+          const documentRevisions = revsDiffBodyForIds(docIDs);
+          const revsDiffResponses = await Promise.all([client.postRevsDiff({ db: database1, documentRevisions }), client.postRevsDiff({ db: database2, documentRevisions })]);
+          // The responses are a map of doc IDs to a map of missing and possible ancestor arrays of rev IDs.
+          // The missing will be our fake rev ID and possible ancestors should be all the leaf revisions.
+          // We can assert these maps match to identify any discrepencies in the rev tree.
+          assert.deepStrictEqual(revsDiffResponses[1].result, revsDiffResponses[0].result);
+          // Return the original list of doc IDs to prepare for the next page
+          return docIDs;
+        }).then(docIds => {
+          // Increment the counter
+          count += docIds.length;
+          if (docIds.length < limit) {
+            // Last page
+            // Set null to break the loop
+            startKey = null;
+            // Assert that we actually got all the docs
+            assert.strictEqual(count, db1DocCount);
+          } else {
+            // Set start key for next page
+            startKey = docIds[limit - 1] + '\u0000';
+          }
+        });
+    } catch (e) {
+      return Promise.reject(e);
     }
   } while (startKey != null);
-  return allDocIds;
+  return true;
 };
+
+function resultRowsToIds(rows) {
+  return rows.map(r => r.id);
+}
+
+function revsDiffBodyForIds(docIDs) {
+  // Make a map of each doc ID to a fake revision
+  // use a fake revision ID to fetch all leaf revisions
+  const fakeRevisionId = '99999-a';
+  const documentRevisions = Object.create(null);
+  docIDs.forEach(id => (documentRevisions[id] = [fakeRevisionId]));
+  return documentRevisions;
+}
 
 module.exports = {
   compare


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test only
- [x] Completed the PR template below:

## Description

Do the post test database comparions batch wise to reduce overhead.

Fixes part of i320

## Approach

The database comparison obtained a full list of document IDs from 2 databases (that should be identical) and proceeded to identify all the missing revisions. For large databases the full ID list being in memory (twice) plus a third copy for the union consumes a significant amount of memory.
Whilst it is potentially useful to know the complete list of missing IDs/revs from an automated test perspective it is preferable for us to "fail fast" instead.
This PR reworks the comparison to a fail fast approach by doing these checks:
* Introduce `getDatabaseInfo` checks upfront and compare the number of docs and deleted docs (if they don't match the databases don't match and we can bail quickly)
* Since when we perform compares the databases are not changing and all docs is sorted by ID, we can perform databases comparison one batch at a time and fail immediately. For each batch:
   * Make requests to both databases in parallel for all docs
   * Perform comparison of the all docs rows from each database (if they don't match then there are some  extra or missing doc IDs) or the winning revision is different between the two databases
    * If the doc IDs/winning revs match, make parallel `postRevsDiff` requests to get all the possible ancestors - these should also match for the 2 databases and if they don't there are some missing revs
    * Use deep strict equal to do the comparisons to get detailed output of differences if there is a failure in the current batch (and break the loop and fail the test at that point).
* Introduce a final check to ensure that the number of docs we saw via all docs matches what we expected from the doc count for the database.

Even when there are no failures this approach is significantly faster than the previous approach (it saves about 25% on build time) and the memory footprint should be much lower too.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to use faster db comparison.

## Monitoring and Logging

- "No change"
