### PR TITLE
Prepare 2.9.17 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 2.9.17 (2024-02-14)
+- [IMPROVED] Examples and related documentation.
+- [IMPROVED] Reduced package size.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.3`.
+- [UPGRADED] `commander` dependency to version `12.0.0`
+- [UPGRADED] Examples to use latest dependencies.
+
 # 2.9.16 (2024-01-10)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.2`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.17-SNAPSHOT",
+  "version": "2.9.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.9.17-SNAPSHOT",
+      "version": "2.9.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.9.17-SNAPSHOT",
+  "version": "2.9.17",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.9.17 release

# Changes
# 2.9.17 (2024-02-14)
- [IMPROVED] Examples and related documentation.
- [IMPROVED] Reduced package size.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.8.3`.
- [UPGRADED] `commander` dependency to version `12.0.0`
- [UPGRADED] Examples to use latest dependencies.