### PR TITLE
Prepare 2.10.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 2.10.0 (unreleased)
+# 2.10.0 (2024-02-28)
 - [NEW] Included `time` in `restored` API events and CLI output.
 - [NEW] Added metadata to backup files.
 - [FIXED] Double output of errors to stderr when using CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.0-SNAPSHOT",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.10.0-SNAPSHOT",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.0-SNAPSHOT",
+  "version": "2.10.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.10.0 release

# Changes

# 2.10.0 (2024-02-28)
- [NEW] Included `time` in `restored` API events and CLI output.
- [NEW] Added metadata to backup files.
- [FIXED] Double output of errors to stderr when using CLI.
- [FIXED] Error for broken JSON in backup files.
- [FIXED] Wrong error code used for incomplete changes item.
- [FIXED] Error if the log file already exists when starting a new backup.
- [REMOVED] Dependency on `async` module.
- [REMOVED] Dependency on `tmp` module.
- [REMOVED] Unused request handling code.
- [IMPROVED] Increased tolerance to server and network errors when spooling changes (via cloudant-node-sdk changes follower).
- [IMPROVED] Avoided double parsing of JSON batches when resuming a backup.
- [IMPROVED] Resumed backups identification of incomplete backup lines during restore.
- [IMPROVED] Added line numbers to errors from reading backup or log files.
- [IMPROVED] Replace custom liner with Node built-in readline.
- [IMPROVED] Added warning that `--buffer-size` has no effect with `--resume`.
- [IMPROVED] Documentation about compatibility.
- [IMPROVED] Resolved linter warnings.
- [IMPROVED] Internal enhancements with promises and pipelines replacing callbacks and event emitters.
- [IMPROVED] Added new test cases and improved test stability.
- [NOTE] Versions older than 2.10.0 cannot restore backups created with 2.10.0. See [compatibility note](README.md#compatibility-note-1).
