### PR TITLE
[Discuss] add attachment backup support

### DIFF
--- a/includes/attachments.js
+++ b/includes/attachments.js
@@ -1,0 +1,40 @@
+const path = require('node:path')
+const fs = require('node:fs').promises
+const util = require('node:util')
+
+async function attachmentBackupHandler (batch) {
+	const { docs } = batch
+	for (let doc of docs) {
+		if (!doc._attachments) { continue }
+		for await (let attachmentName of Object.keys(doc._attachments)) {
+			const attachment = doc._attachments[attachmentName]
+			const parameters = {
+				db: this.dbName,
+				docId: doc._id,
+				attachmentName
+			}
+			const attachmentStream = await this.service.getAttachment(parameters)
+			attachment.data = toBase64(await streamToBuffer(attachmentStream.result))
+			delete attachment.stub
+			delete attachment.length
+			delete attachment.revpos
+		}
+	}
+	return batch
+}
+
+module.exports.attachmentBackupHandler = attachmentBackupHandler
+
+// h/t: https://stackoverflow.com/questions/10623798/how-do-i-read-the-contents-of-a-node-js-stream-into-a-string-variable
+function streamToBuffer (stream) {
+  const chunks = [];
+  return new Promise((resolve, reject) => {
+	stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+	stream.on('error', (err) => reject(err));
+	stream.on('end', () => resolve(Buffer.concat(chunks)));
+  })
+}
+
+function toBase64 (data) {
+	return Buffer.from(data).toString('base64')
+}

--- a/includes/restore.js
+++ b/includes/restore.js
@@ -16,9 +16,10 @@
 const debug = require('debug')('couchbackup:restore');
 const { Liner } = require('../includes/liner.js');
 const { Restore } = require('../includes/restoreMappings.js');
-const { BatchingStream, MappingStream } = require('./transforms.js');
+const { BatchingStream, MappingStream, SideEffect } = require('./transforms.js');
 const { Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
+ 
 
 /**
  * Function for performing a restore.


### PR DESCRIPTION
> DO NOT USE THIS TOOL FOR DATABASES CONTAINING ATTACHMENTS

No more!

—

This PR aims to open the discussion of adding attachment support to couchbackup with a proof of concept.

The open questions here are

1. should couchbackup gain support for attachments or not?
2. if yes, is the general direction of this PR the right one, or should this look substantially different?

## How it works: backup 

1. During backup, we pipe all document batches through a `MappingStream` stream.
2. For each doc body in a batch, we check for` _attachments` and skip if there is none
3. For each attachment in `_attachments`:
    1. Fetch the attachment data from the source in a streaming fashion.
    2. Save it’s base64’d data into `attachments.data`
    3. Delete attachment properties `stub`, `revpos` and `length` as they will be restored by the target (todo, check if true for `revpos`).
 
## How it works: restore

No changes, we stored things in a way that can be restored with the existing `_bulk_docs` implementation.

## Limitations / Future directions

1. ~Backup as implemented breaks the “pipe everything to `stdout`” by writing files to the current dir and sending JSON docs to `stdout`.~
    1. ~This isn’t necessarily a problem, but it’d be a little nicer if we implemented an `--output-dir` option that takes a directory to where the backup is written. This could then be `<output-dir>/docs.json` and `<output-dir>/attachments/<digest>` which folks can then post-process with compression or encryption like before.~
    2. ~Alternatively, we could produce a `multipart/related` stream that stores everything into one file. Attachment deduplication becomes a little less easy here.~
    3.  Or we base64 into the single file, which is what the current implementation does, h/t @rnewson 
4. ~Currently attachments are piped through an async API and effectively buffers attachments in-process one at a time, this can be trivially optimised to a fully streaming architecture.~
5. ~On restore, we did not want to mess with the `_bulk_docs` insertion, so we opted for base64-ing the attachment data. As this is not optional, a future variant would take attachment-docs out of the `_bulk_docs` batch and do a [`multipart/related` request just for one doc and all its attachments](https://docs.couchdb.org/en/stable/api/document/common.html#creating-multiple-attachments).~

What do y’all think?