### PR TITLE
Prepare 2.10.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 2.10.1 (2024-05-14)
 - [IMPROVED] Updated documentation.
-- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.9.0`.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.9.1`.
 
 # 2.10.0 (2024-02-28)
 - [NEW] Included `time` in `restored` API events and CLI output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.1-SNAPSHOT",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.10.1-SNAPSHOT",
+      "version": "2.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.1-SNAPSHOT",
+  "version": "2.10.1",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.10.1 release

# Changes

# 2.10.1 (2024-05-14)
- [IMPROVED] Updated documentation.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.9.1`.
