### PR TITLE
Add unreliable network tests with toxiproxy

### DIFF
--- a/test-network/conditions.js
+++ b/test-network/conditions.js
@@ -12,35 +12,127 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint space-before-function-paren: ["error", { "anonymous": "ignore" }] */
 /* global after before describe */
 'use strict';
+
+const assert = require('assert');
+const axios = require('axios');
+const net = require('node:net');
+
+const httpProxy = require('http-proxy');
 
 // Import the common hooks
 require('../test/hooks.js');
 
 const poisons = [
-  'normal',
-  'bandwidth-limit',
-  'latency',
-  'slow-read',
-  'rate-limit'
+  {
+    name: 'normal'
+  },
+  {
+    name: 'bandwidth-limit-upstream',
+    type: 'bandwidth',
+    stream: 'upstream', // client -> server
+    attributes: { rate: 512 } // 0.5 MB/s
+  },
+  {
+    name: 'bandwidth-limit-downstream',
+    type: 'bandwidth',
+    stream: 'downstream', // client <- server
+    attributes: { rate: 512 }
+  },
+  {
+    name: 'latency',
+    type: 'latency',
+    attributes: { latency: 875, jitter: 625 }, // max: 1500, mix: 250
+    toxicity: 0.6 // probability: 60%
+  },
+  {
+    name: 'slow-read',
+    type: 'slicer',
+    attributes: { average_size: 256, delay: 100 },
+    toxicity: 0.1 // probability: 10%
+  }
 ];
 
-poisons.forEach(function(poison) {
-  describe('unreliable network tests (using poison ' + poison + ')', function() {
-    before('start server', function() {
+const proxyURL = process.env.PROXY_URL + '/proxies/couchdb';
 
-      // **************************
-      // Currently these tests do nothing
-      // pending resolution of https://github.com/IBM/couchbackup/issues/360
-      // to add a new toxic server
-      // **************************
+const waitForSocket = (port) => {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const connect = () => socket.connect({ port });
+    let reConnect = false;
+
+    socket.on('connect', async () => {
+      if (reConnect !== false) {
+        clearInterval(reConnect);
+        reConnect = false;
+      }
+      socket.end();
+      resolve(socket);
     });
 
-    after('stop server', function() {
+    socket.on('error', () => {
+      if (reConnect === false) {
+        reConnect = setInterval(connect, 1000);
+      }
     });
 
-    delete require.cache[require.resolve('../test/ci_e2e.js')];
-    require('../test/ci_e2e.js');
+    connect();
+  });
+};
+
+describe('unreliable network tests', function () {
+  let proxy;
+  before('add proxy', async function () {
+    // wait up to 10 sec for both proxies to allocate ports.
+    this.timeout(10000);
+
+    proxy = httpProxy.createProxyServer({
+      target: process.env.COUCH_BACKEND_URL,
+      changeOrigin: true
+    }).listen(8080);
+
+    await waitForSocket(8080);
+
+    const toxiProxy = {
+      name: 'couchdb',
+      listen: '127.0.0.1:8888',
+      upstream: '127.0.0.1:8080',
+      enabled: true
+    };
+    const resp = await axios.post(process.env.PROXY_URL + '/proxies', toxiProxy);
+    assert.equal(resp.status, 201, 'Should create proxy "couchdb".');
+    await waitForSocket(8888);
+  });
+
+  after('remove proxy', async function () {
+    const resp = await axios.delete(proxyURL);
+    assert.equal(resp.status, 204, 'Should remove proxy "couchdb".');
+    // shutdown http proxy
+    return new Promise((resolve) => {
+      proxy.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  poisons.forEach(function (poison) {
+    describe(`tests using poison '${poison.name}'`, function () {
+      before(`add toxic ${poison.name}`, async function () {
+        if (poison.name === 'normal') return;
+        const resp = await axios.post(proxyURL + '/toxics', poison);
+        assert.equal(resp.status, 200, `Should create toxic ${poison.name}`);
+      });
+
+      after(`remove toxic ${poison.name}`, async function () {
+        if (poison.name === 'normal') return;
+        const resp = await axios.delete(proxyURL + '/toxics/' + poison.name);
+        assert.equal(resp.status, 204, `Should remove toxic ${poison.name}`);
+      });
+
+      delete require.cache[require.resolve('../test/ci_e2e.js')];
+      require('../test/ci_e2e.js');
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

This PR switches back on unreliable network tests with use of toxiproxy.

The original tests been:

| test | conditions | comment | 
| --- | --- | --- | 
| normal | No poisons to add | |
| bandwidth-limit | `poison(tpoisons.bandwidth({ bytes: 512, threshold: 1 }));` | 0.5 MB/s |
| latency | `poison(tpoisons.latency({ max: 1500, min: 250 })).withRule(trules.probability(60))` | |
| slow-read | `poison(tpoisons.slowRead({ chunk: 256, threshold: 1 })).withRule(trules.timeThreshold({ duration: 1, period: 100 }))` | Slow read for 10 % of the time e.g. 1 ms in every 100 | 
| rate-limit | `'/*/_bulk_get' poison(tpoisons.rateLimit({ limit: 20, threshold: 1000 }))` + `'/*/_bulk_docs' poison(tpoisons.rateLimit({ limit: 10, threshold: 1000 }))` | Simulate the Cloudant free plan with 20 lookups ps and 10 writes ps |


New tests are trying to match those with an exception of `rate-limit` - toxiproxy been tcp proxy can't work on HTTP level and create rules per URL or http request. Instead `bandwidth-limit` test extended to check both upstream and downstream throttling. 

Fixes #360 

## Approach

- In Jenkins for `test-network/conditions` testSuite we are switching to IAM based auth and using `http://127.0.0.1:8888` as `$COUCH_URL`
- New before block in `test-network/conditions` adds proxy on port 8080 and toxiproxy in fron of that on port 8888.
- Toxics are injected before each run, same as before.
- The run itself is `ci_e2e.js` test or backup/restore of animalsdb. The run of `largedb` excluded in Jenkins.

**Note**

Before merging Jenkins needs rollback for `RUN_TOXY_TESTS` in all blocks and set it back on 'Network Node LTS' stage. 

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
