### PR TITLE
Prepare 2.10.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 2.10.2 (2024-08-19)
+
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.10.1`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.0.1` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to minimum version `1.7.4` to match version provided from `ibm-cloud-sdk-core`.
+- [UPGRADED] `commander` dependency to version `12.1.0`
+- [UPGRADED] `debug` dependency to version `4.3.6`.
+
 # 2.10.1 (2024-05-14)
 - [IMPROVED] Updated documentation.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.9.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.2-SNAPSHOT",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.10.2-SNAPSHOT",
+      "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.2-SNAPSHOT",
+  "version": "2.10.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.10.2 release

# Changes
<!-- Paste the changes information here -->

# 2.10.2 (2024-08-19)

- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.10.1`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.0.1` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to minimum version `1.7.4` to match version provided from `ibm-cloud-sdk-core`.
- [UPGRADED] `commander` dependency to version `12.1.0`
- [UPGRADED] `debug` dependency to version `4.3.6`.
