### PR TITLE
Prepare 2.11.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
-# Unreleased
+# 2.11.0 (2024-09-24)
 - [NEW] *EXPERIMENTAL/UNSUPPORTED* Add `attachments` option to backup and restore attachments for Apache CouchDB.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.10.3`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.0.2` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `debug` dependency to version `4.3.7`.
 - [NOTE] The `attachments` option is not supported. Do not use for IBM Cloudant backups.
 
 # 2.10.2 (2024-08-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       },
       "peerDependencies": {
         "axios": "^1.7.4",
-        "ibm-cloud-sdk-core": "^5.0.1",
+        "ibm-cloud-sdk-core": "^5.0.2",
         "retry-axios": "^2.6.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.3-SNAPSHOT",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.10.3-SNAPSHOT",
+      "version": "2.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.10.3-SNAPSHOT",
+  "version": "2.11.0",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "4.3.7"
   },
   "peerDependencies": {
-    "ibm-cloud-sdk-core": "^5.0.1",
+    "ibm-cloud-sdk-core": "^5.0.2",
     "retry-axios": "^2.6.0",
     "axios": "^1.7.4"
   },


### PR DESCRIPTION
# Proposed 2.11.0 release

# Changes

# 2.11.0 (2024-09-24)
- [NEW] *EXPERIMENTAL/UNSUPPORTED* Add `attachments` option to backup and restore attachments for Apache CouchDB.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.10.3`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.0.2` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `debug` dependency to version `4.3.7`.
- [NOTE] The `attachments` option is not supported. Do not use for IBM Cloudant backups.
