### PR TITLE
fix: interceptor ordering with retries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.12.0 (unreleased)
+- [FIXED] Error messages from retried requests.
+
 # 2.11.0 (2024-09-24)
 - [NEW] *EXPERIMENTAL/UNSUPPORTED* Add `attachments` option to backup and restore attachments for Apache CouchDB.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.10.3`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 2.12.0 (unreleased)
 - [FIXED] Error messages from retried requests.
+- [NOTE] Removed `retry-axios` from peerDependencies.
 
 # 2.11.0 (2024-09-24)
 - [NEW] *EXPERIMENTAL/UNSUPPORTED* Add `attachments` option to backup and restore attachments for Apache CouchDB.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,7 @@
       },
       "peerDependencies": {
         "axios": "^1.7.4",
-        "ibm-cloud-sdk-core": "^5.0.2",
-        "retry-axios": "^2.6.0"
+        "ibm-cloud-sdk-core": "^5.0.2"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "peerDependencies": {
     "ibm-cloud-sdk-core": "^5.0.2",
-    "retry-axios": "^2.6.0",
     "axios": "^1.7.4"
   },
   "main": "app.js",


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fix interceptor ordering issue and tidy up.

Fixes i414

## Approach

* Enable retries  _after_ all other interceptors are registered
* Replace custom retry configuration with SDK's `enableRetries` and remove related peerDependency.
* Use named functions for interceptors and ensure user-agent is set on token requests also.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

Retries are covered by existing tests.

## Monitoring and Logging

- "No change"
