### PR TITLE
Prepare 2.11.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.11.2 (2025-01-16)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.0`.
+- [UPGRADED] `commander` dependency to version `13.0.0`
+- [UPGRADED] `debug` dependency to version `4.4.0`.
+
 # 2.11.1 (2024-11-19)
 - [FIXED] Error messages from retried requests.
 - [IMPROVED] Updated error response messages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.2-SNAPSHOT",
+  "version": "2.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.2-SNAPSHOT",
+      "version": "2.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.2-SNAPSHOT",
+  "version": "2.11.2",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.2 release

# Changes
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.0`.
- [UPGRADED] `commander` dependency to version `13.0.0`
- [UPGRADED] `debug` dependency to version `4.4.0`.