### PR TITLE
fix: avoid double encoding specials in db names

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|test/fixtures|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-27T17:31:46Z",
+  "generated_at": "2025-01-21T10:28:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -244,7 +244,7 @@
         "hashed_secret": "41a269ae4f24dab3ddf96b401f1ada5dfdfc5f08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 198,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.11.3 (unreleased)
+- [FIXED] Incorrect encoding of special characters in database names.
+- [UPGRADED] `commander` dependency to version `13.1.0`
+
 # 2.11.2 (2025-01-16)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.0`.
 - [UPGRADED] `commander` dependency to version `13.0.0`

--- a/includes/request.js
+++ b/includes/request.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2024 IBM Corp. All rights reserved.
+// Copyright © 2017, 2025 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ function newSimpleClient(rawUrl, opts) {
   // Split the URL to separate service from database
   // Use origin as the "base" to remove auth elements
   const actUrl = new URL(url.pathname.substring(0, url.pathname.lastIndexOf('/')), url.origin);
-  const dbName = url.pathname.substring(url.pathname.lastIndexOf('/') + 1);
+  const dbName = decodeURIComponent(url.pathname.substring(url.pathname.lastIndexOf('/') + 1));
   let authenticator;
   // Default to cookieauth unless an IAM key is provided
   if (opts.iamApiKey) {

--- a/test/cliutils.js
+++ b/test/cliutils.js
@@ -1,0 +1,34 @@
+// Copyright © 2025 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+
+const cliutils = require('../includes/cliutils.js');
+const assert = require('assert');
+
+describe('#unit Check URL handling', function() {
+  it('should encode database names', async function() {
+    const server = 'http://foo.example';
+    const dbName = 'a_$()+/-';
+    const expectedEncodedDbName = 'a_%24()%2B%2F-';
+    const encodedDbName = encodeURIComponent(dbName);
+    assert.strictEqual(encodedDbName, 'a_%24()%2B%2F-',
+        `The encoded DB name was ${encodedDbName} but should match the expected ${expectedEncodedDbName}`);
+    const expectedUrl = `${server}/${expectedEncodedDbName}`;
+    const url = cliutils.databaseUrl(server, dbName);
+    assert.strictEqual(url, expectedUrl,
+      `The url was ${url} but should be ${expectedUrl}`
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixed encoding of special characers in database names.

Fixes #801

## Approach

The command line database name parameter is encoded into a URL (for historical API compatibility reasons) and then extracted again for use with the client HTTP calls.
The client automatically encodes the db parameter before using it in a URL so to avoid double-encoding we need to decode it first.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - `test/cliutils.js` `#unit Check URL handling` `should encode database names` - to validate the encoding of the CLI parameter into the internal URL
    - `test.request.js` `#unit Check database names` `should handle special characters` - to check that the db name is decoded for the client config object and re-encded by the client during a request

## Monitoring and Logging

- "No change"
