### PR TITLE
Prepare 2.11.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
-# 2.11.3 (unreleased)
-- [FIXED] Incorrect encoding of special characters in database names.
+# 2.11.3 (2025-01-23)
+- [FIXED] Encoding of special characters in database names.
 - [UPGRADED] `commander` dependency to version `13.1.0`
 
 # 2.11.2 (2025-01-16)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.3-SNAPSHOT",
+  "version": "2.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.3-SNAPSHOT",
+      "version": "2.11.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.3-SNAPSHOT",
+  "version": "2.11.3",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.3 release

# Changes

# 2.11.3 (2025-01-23)
- [FIXED] Encoding of special characters in database names.
- [UPGRADED] `commander` dependency to version `13.1.0`