### PR TITLE
test: avoid encryption key derivation warning

### DIFF
--- a/test/citestutils.js
+++ b/test/citestutils.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2024 IBM Corp. All rights reserved.
+// Copyright © 2017, 2025 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -454,14 +454,15 @@ async function assertGzipFile(path) {
 
 async function assertEncryptedFile(path) {
   // Openssl encrypted files start with Salted
-  const expectedBytes = Buffer.from('Salted');
-  const buffer = Buffer.alloc(6);
+  // base64 encoded is U2FsdGVk
+  const expectedBytes = Buffer.from('U2FsdGVk');
+  const buffer = Buffer.alloc(8);
   let fileHandle;
   try {
     fileHandle = await open(path, 'r');
-    // Read the first six bytes
-    readSync(fileHandle.fd, buffer, 0, 6, 0);
-    // Assert first 6 characters of the file are "Salted"
+    // Read the first eight bytes
+    readSync(fileHandle.fd, buffer, 0, 8, 0);
+    // Assert first 8 characters of the file are "U2FsdGVk"
     assert.deepStrictEqual(buffer, expectedBytes, 'The backup file should be encrypted.');
   } finally {
     await fileHandle?.close();

--- a/test/test_process.js
+++ b/test/test_process.js
@@ -1,4 +1,4 @@
-// Copyright © 2023, 2024 IBM Corp. All rights reserved.
+// Copyright © 2023, 2025 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,9 +150,24 @@ module.exports = {
     return new TestProcess('gunzip', []);
   },
   cliEncrypt: function() {
-    return new TestProcess('openssl', ['aes-128-cbc', '-pass', 'pass:12345']);
+    return new TestProcess('openssl', [
+      'enc',
+      '-base64',
+      '-aes256',
+      '-md', 'sha512',
+      '-pbkdf2',
+      '-iter', '100',
+      '-pass', 'pass:12345']);
   },
   cliDecrypt: function() {
-    return new TestProcess('openssl', ['aes-128-cbc', '-d', '-pass', 'pass:12345']);
+    return new TestProcess('openssl', [
+      'enc',
+      '-d',
+      '-base64',
+      '-aes256',
+      '-md', 'sha512',
+      '-pbkdf2',
+      '-iter', '100',
+      '-pass', 'pass:12345']);
   }
 };


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - test code
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - test code
- [x] Completed the PR template below:

## Description

Avoid encyrption key derivation warning in test code.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run the encryption tests.

### 2. What you expected to happen

No warnings in logs.

### 3. What actually happened

```
[2025-01-27T13:48:42.014Z] *** WARNING : deprecated key derivation used.
[2025-01-27T13:48:42.014Z] Using -iter or -pbkdf2 would be better.
```

## Approach

Change the options used on the `openssl` process to avoid the warning.
Also base64 encode the output and adjust the assertion to match.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because to avoid emitting warning and assert on base64 output.

## Monitoring and Logging

- "No change"
