### PR TITLE
ci: rename node versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,19 +17,34 @@ def getEnvForSuite(suiteName, version) {
 
   def envVars = []
 
+  portOffset = 0
+  switch(version) {
+    case 'old-maintenance':
+      portOffset += 30
+      break
+    case 'maintenance':
+      portOffset += 20
+      break
+    case 'active':
+      portOffset += 10
+      break
+    default:
+      break
+  }
+
   // Add test suite specific environment variables
   switch(suiteName) {
     case 'test':
-      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7700 + version.toInteger()}")
+      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7700 + portOffset}")
       break
     case 'test-network/conditions':
       envVars.add("CLOUDANT_IAM_TOKEN_URL=${SDKS_TEST_IAM_URL}")
       envVars.add("TEST_TIMEOUT_MULTIPLIER=50")
-      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7800 + version.toInteger()}")
+      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7800 + portOffset}")
       break
     case 'test-iam':
       envVars.add("CLOUDANT_IAM_TOKEN_URL=${SDKS_TEST_IAM_URL}")
-      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7900 + version.toInteger()}")
+      envVars.add("COUCHBACKUP_MOCK_SERVER_PORT=${7900 + portOffset}")
       break
     default:
       error("Unknown test suite environment ${suiteName}")
@@ -161,45 +176,45 @@ pipeline {
             }
           }
         }
-        stage('Node LTS') {
+        stage('Node Active LTS') {
           steps {
             script{
-              runTest('22')
+              runTest('active')
             }
           }
         }
-        stage('IAM Node LTS') {
+        stage('IAM Node Active LTS') {
           steps {
             script{
-              runTest('22', '-i -g \'#unit|#slowe\'', 'test-iam')
+              runTest('active', '-i -g \'#unit|#slowe\'', 'test-iam')
             }
           }
         }
-        stage('Network Node LTS') {
+        stage('Network Node Active LTS') {
           when {
             beforeAgent true
             environment name: 'RUN_TOXY_TESTS', value: 'true'
           }
           steps {
             script{
-              runTest('22', '', 'test-network/conditions')
+              runTest('active', '', 'test-network/conditions')
             }
           }
         }
-        stage('Node 18x') {
+        stage('Node Old Maintenance LTS') {
           steps {
-            container('node18') {
+            container('node-old-maintenance-lts') {
               script{
-                runTest('18')
+                runTest('old-maintenance')
               }
             }
           }
         }
-        stage('Node 20x') {
+        stage('Node Maintenance LTS') {
           steps {
-            container('node20') {
+            container('node-maintenance-lts') {
               script{
-                runTest('20')
+                runTest('maintenance')
               }
             }
           }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - build only
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - build only
- [x] Completed the PR template below:

## Description

Update Node version matrix in CI.

Fixes part of i399.

## Approach

* Rename containers to match new names provided by kube agent template.
* Mock server port offset by constant, not version number.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes - note build will fail until new template is merged.

## Monitoring and Logging

- "No change"
