### PR TITLE
Prepare 2.11.5 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.11.5 (2025-03-11)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.2`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.3.2` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to minimum version `1.8.2` to match version provided from `ibm-cloud-sdk-core`.
+
 # 2.11.4 (2025-02-11)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.1`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.5-SNAPSHOT",
+  "version": "2.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.5-SNAPSHOT",
+      "version": "2.11.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.5-SNAPSHOT",
+  "version": "2.11.5",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed `2.11.5` release

# Changes

# 2.11.5 (2025-03-11)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.2`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.3.2` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to minimum version `1.8.2` to match version provided from `ibm-cloud-sdk-core`.
