### PR TITLE
Remove Node.js version `18` support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [NOTE] Updated minimum supported engine to Node.js 20 LTS.
+
 # 2.11.5 (2025-03-11)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.2`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.3.2` to match version provided from `@ibm-cloud/cloudant`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install -g @cloudant/couchbackup
 ```
 
 ### Requirements
-* Node.js LTS version 18, 20, or 22.
+* Node.js LTS version 20, or 22.
 * The minimum required CouchDB version is 2.0.0.
 
 ### Snapshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "uuid": "11.1.0"
       },
       "engines": {
-        "node": "^18 || ^20 || ^22"
+        "node": "^20 || ^22"
       },
       "peerDependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^18 || ^20 || ^22"
+    "node": "^20 || ^22"
   },
   "dependencies": {
     "@ibm-cloud/cloudant": "0.12.3",


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Remove EOL Node.js `18` from supported versions.
Fixes part of i458

## Approach

* Update `README.md` to list Node.js `20` as the minimum supported version.
* Update `package.json` `engine` list to include Node.js LTS versions `20` and `22` (note that `24` will be production ready LTS in October)
* Add a note to `CHANGES.md` for next release.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Test matrix versions are updated separately to remove Node.js 18.

## Monitoring and Logging

- "No change"
