### PR TITLE
Prepare 2.11.6 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-# Unreleased
+# 2.11.6 (2025-05-01)
+- [IMPROVED] Avoid poll delay collecting changes from empty databases.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.3`.
 - [NOTE] Updated minimum supported engine to Node.js 20 LTS.
 
 # 2.11.5 (2025-03-11)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.6-SNAPSHOT",
+  "version": "2.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.6-SNAPSHOT",
+      "version": "2.11.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.6-SNAPSHOT",
+  "version": "2.11.6",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.6 release

# Changes

# 2.11.6 (2025-05-01)
- [IMPROVED] Avoid poll delay collecting changes from empty databases.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.3`.
- [NOTE] Updated minimum supported engine to Node.js 20 LTS.
