### PR TITLE
fix: sorting as SQ suggests

### DIFF
--- a/test/transforms.js
+++ b/test/transforms.js
@@ -175,7 +175,7 @@ describe('#unit should do transforms', function() {
       }).then((outputArray) => {
         if (concurrency) {
           // Order may change if we're using concurrency so sort before comparing
-          outputArray.sort();
+          outputArray.sort((a, b) => a - b);
         }
         assert.deepStrictEqual(expected, outputArray, 'The output should be mapped.');
       });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

JavaScript provides built-in methods to sort arrays, making it convenient for developers to manipulate data. There are two primary ways to sort an array:

`Array.prototype.sort()`: This method sorts the elements of an array in place and returns the sorted array.
`Array.prototype.toSorted()`: This method is designed to return a new sorted array, leaving the original array unchanged.
The default sort order is lexicographic (dictionary) order, based on the string representation of the elements. This means that when sorting an array of strings, numbers, or other elements, they are converted to strings and sorted according to their Unicode code points (UTF-16). For most cases, this default behavior is suitable when sorting an array of strings.

However, it’s essential to be aware of potential pitfalls when sorting arrays of non-string elements, particularly numbers. The lexicographic order may not always produce the expected results for numbers:

```js
const numbers = [10, 2, 30, 1, 5];
numbers.sort(); // Noncompliant: lexicographic sort
console.log(numbers); // Output: [1, 10, 2, 30, 5]
```

## Approach

To sort numbers correctly, you must provide a custom comparison function that returns the correct ordering:

```js
const numbers = [10, 2, 30, 1, 5];
numbers.sort((a, b) => a - b);
console.log(numbers); // Output: [1, 2, 5, 10, 30]
```

## Schema & API Changes
- No change


## Security and Privacy

- No change

## Testing

- No new tests because this fixed one semantical issue in one test.


## Monitoring and Logging

- No change
