### PR TITLE
Proposed 2.11.9 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.11.9 (2025-07-25)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.7`.
+
 # 2.11.8 (2025-07-23)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.6`.
 - [NOTE] Add AI code policy to contributing guide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.9-SNAPSHOT",
+  "version": "2.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.9-SNAPSHOT",
+      "version": "2.11.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.9-SNAPSHOT",
+  "version": "2.11.9",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.9 release

# Changes

# 2.11.9 (2025-07-25)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.7`.
