### PR TITLE
Prepare 2.11.10 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.11.9 (2025-08-29)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.8`.
+
 # 2.11.9 (2025-07-25)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.7`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.4.2` to match version provided from `@ibm-cloud/cloudant`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 2.11.9 (2025-07-25)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.7`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.4.2` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to minimum version `1.11.0` to match version provided from `ibm-cloud-sdk-core`.
 
 # 2.11.8 (2025-07-23)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.6`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.10-SNAPSHOT",
+  "version": "2.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.10-SNAPSHOT",
+      "version": "2.11.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.10-SNAPSHOT",
+  "version": "2.11.10",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.10 release

# Changes

# 2.11.9 (2025-08-29)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.8`.