### PR TITLE
Prepare 2.11.15 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.11.15 (2026-04-03)
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.17`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.4.10`  to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to version `1.14.0` to match version provided from `@ibm-cloud/cloudant`.
+
 # 2.11.14 (2026-03-19)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.16`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to minimum version `5.4.9` to match version provided from `@ibm-cloud/cloudant`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.15-SNAPSHOT",
+  "version": "2.11.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.15-SNAPSHOT",
+      "version": "2.11.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.15-SNAPSHOT",
+  "version": "2.11.15",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.15 release

# Changes

# 2.11.15 (2026-04-03)
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.17`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.4.10`  to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to version `1.14.0` to match version provided from `@ibm-cloud/cloudant`.
