### PR TITLE
fix: avoid duplicate CLI option config

### DIFF
--- a/includes/parser.js
+++ b/includes/parser.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2025 IBM Corp. All rights reserved.
+// Copyright © 2017, 2026 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,60 +12,84 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const { Command } = require('commander');
+const path = require('path');
 const cliutils = require('./cliutils.js');
 const config = require('./config.js');
 const error = require('./error.js');
-const path = require('path');
 const pkg = require('../package.json');
 
+// Option CLI defaults
+const defaults = config.cliDefaults();
+
+const backupProgram = new Command()
+  .version(pkg.version)
+  .description('Backup a CouchDB/Cloudant database to a backup text file.')
+  .usage('[options...]')
+  .option('-a, --attachments',
+    cliutils.getUsage('*EXPERIMENTAL/UNSUPPORTED*: enable backup of attachments', defaults.attachments))
+  .option('-b, --buffer-size <n>',
+    cliutils.getUsage('number of documents fetched at once', defaults.bufferSize),
+    Number)
+  .option('-d, --db <db>',
+    cliutils.getUsage('name of the database to backup', defaults.db))
+  .option('-k, --iam-api-key <API key>',
+    cliutils.getUsage('IAM API key to access the Cloudant server'))
+  .option('-l, --log <file>',
+    cliutils.getUsage('file to store logging information during backup; invalid in "shallow" mode', 'a temporary file'),
+    path.normalize)
+  .option('-m, --mode <mode>',
+    cliutils.getUsage('"shallow" if only a superficial backup is done (ignoring conflicts and revision tokens), else "full" for complete backup', defaults.mode),
+    (mode) => { return mode.toLowerCase(); })
+  .option('-o, --output <file>',
+    cliutils.getUsage('file name to store the backup data', 'stdout'),
+    path.normalize)
+  .option('-p, --parallelism <n>',
+    cliutils.getUsage('number of HTTP requests to perform in parallel when performing a backup; ignored in "shallow" mode', defaults.parallelism),
+    Number)
+  .option('-q, --quiet',
+    cliutils.getUsage('suppress batch messages', defaults.quiet))
+  .option('-r, --resume',
+    cliutils.getUsage('continue a previous backup from its last known position; invalid in "shallow" mode', defaults.resume))
+  .option('-t, --request-timeout <n>',
+    cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
+    Number)
+  .option('-u, --url <url>',
+    cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url));
+
+const restoreProgram = new Command()
+  .version(pkg.version)
+  .description('Restore a CouchDB/Cloudant database from a backup text file.')
+  .usage('[options...]')
+  .option('-a, --attachments',
+    cliutils.getUsage('*EXPERIMENTAL/UNSUPPORTED*: enable restore of attachments', defaults.attachments))
+  .option('-b, --buffer-size <n>',
+    cliutils.getUsage('number of documents restored at once', defaults.bufferSize),
+    Number)
+  .option('-d, --db <db>',
+    cliutils.getUsage('name of the new, existing database to restore to', defaults.db))
+  .option('-k, --iam-api-key <API key>',
+    cliutils.getUsage('IAM API key to access the Cloudant server'))
+  .option('-p, --parallelism <n>',
+    cliutils.getUsage('number of HTTP requests to perform in parallel when restoring a backup', defaults.parallelism),
+    Number)
+  .option('-q, --quiet',
+    cliutils.getUsage('suppress batch messages', defaults.quiet))
+  .option('-t, --request-timeout <n>',
+    cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
+    Number)
+  .option('-u, --url <url>',
+    cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url));
+
 function parseBackupArgs() {
-  const { program } = require('commander');
-
-  // Option CLI defaults
-  const defaults = config.cliDefaults();
-
   // Options set by environment variables
   const envVarOptions = {};
   config.applyEnvironmentVariables(envVarOptions);
 
-  program
-    .version(pkg.version)
-    .description('Backup a CouchDB/Cloudant database to a backup text file.')
-    .usage('[options...]')
-    .option('-a, --attachments',
-      cliutils.getUsage('*EXPERIMENTAL/UNSUPPORTED*: enable backup of attachments', defaults.attachments))
-    .option('-b, --buffer-size <n>',
-      cliutils.getUsage('number of documents fetched at once', defaults.bufferSize),
-      Number)
-    .option('-d, --db <db>',
-      cliutils.getUsage('name of the database to backup', defaults.db))
-    .option('-k, --iam-api-key <API key>',
-      cliutils.getUsage('IAM API key to access the Cloudant server'))
-    .option('-l, --log <file>',
-      cliutils.getUsage('file to store logging information during backup; invalid in "shallow" mode', 'a temporary file'),
-      path.normalize)
-    .option('-m, --mode <mode>',
-      cliutils.getUsage('"shallow" if only a superficial backup is done (ignoring conflicts and revision tokens), else "full" for complete backup', defaults.mode),
-      (mode) => { return mode.toLowerCase(); })
-    .option('-o, --output <file>',
-      cliutils.getUsage('file name to store the backup data', 'stdout'),
-      path.normalize)
-    .option('-p, --parallelism <n>',
-      cliutils.getUsage('number of HTTP requests to perform in parallel when performing a backup; ignored in "shallow" mode', defaults.parallelism),
-      Number)
-    .option('-q, --quiet',
-      cliutils.getUsage('suppress batch messages', defaults.quiet))
-    .option('-r, --resume',
-      cliutils.getUsage('continue a previous backup from its last known position; invalid in "shallow" mode', defaults.resume))
-    .option('-t, --request-timeout <n>',
-      cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
-      Number)
-    .option('-u, --url <url>',
-      cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url))
-    .parse(process.argv);
+  backupProgram.parse(process.argv);
 
   // Remove defaults that don't apply when using shallow mode
-  if (program.opts().mode === 'shallow' || envVarOptions.mode === 'shallow') {
+  if (backupProgram.opts().mode === 'shallow' || envVarOptions.mode === 'shallow') {
     delete defaults.parallelism;
     delete defaults.log;
     delete defaults.resume;
@@ -73,7 +97,7 @@ function parseBackupArgs() {
 
   // Apply the options in order so that the CLI overrides env vars and env variables
   // override defaults.
-  const opts = Object.assign({}, defaults, envVarOptions, program.opts());
+  const opts = Object.assign({}, defaults, envVarOptions, backupProgram.opts());
 
   if (opts.resume && (opts.log === defaults.log)) {
     // If resuming and the log file arg is the newly generated tmp name from defaults then we know that --log wasn't specified.
@@ -84,8 +108,6 @@ function parseBackupArgs() {
 }
 
 function parseRestoreArgs() {
-  const { program } = require('commander');
-
   // Option CLI defaults
   const defaults = config.cliDefaults();
 
@@ -93,34 +115,11 @@ function parseRestoreArgs() {
   const envVarOptions = {};
   config.applyEnvironmentVariables(envVarOptions);
 
-  program
-    .version(pkg.version)
-    .description('Restore a CouchDB/Cloudant database from a backup text file.')
-    .usage('[options...]')
-    .option('-a, --attachments',
-      cliutils.getUsage('*EXPERIMENTAL/UNSUPPORTED*: enable restore of attachments', defaults.attachments))
-    .option('-b, --buffer-size <n>',
-      cliutils.getUsage('number of documents restored at once', defaults.bufferSize),
-      Number)
-    .option('-d, --db <db>',
-      cliutils.getUsage('name of the new, existing database to restore to', defaults.db))
-    .option('-k, --iam-api-key <API key>',
-      cliutils.getUsage('IAM API key to access the Cloudant server'))
-    .option('-p, --parallelism <n>',
-      cliutils.getUsage('number of HTTP requests to perform in parallel when restoring a backup', defaults.parallelism),
-      Number)
-    .option('-q, --quiet',
-      cliutils.getUsage('suppress batch messages', defaults.quiet))
-    .option('-t, --request-timeout <n>',
-      cliutils.getUsage('milliseconds to wait for a response to a HTTP request before retrying the request', defaults.requestTimeout),
-      Number)
-    .option('-u, --url <url>',
-      cliutils.getUsage('URL of the CouchDB/Cloudant server', defaults.url))
-    .parse(process.argv);
+  restoreProgram.parse(process.argv);
 
   // Apply the options in order so that the CLI overrides env vars and env variables
   // override defaults.
-  const opts = Object.assign({}, defaults, envVarOptions, program.opts());
+  const opts = Object.assign({}, defaults, envVarOptions, restoreProgram.opts());
 
   return opts;
 }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - covered by existing tests
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - refactor for tests, no user facing changes
- [x] Completed the PR template below:

## Description

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Commander 15 update causes some tests to fail - see #956

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

CLI tests failed with
```
Error: Cannot add option '-V, --version' to command 'test' due to conflicting flag '--version'
-  already used by option '-V, --version'
```

Commander `15` enforces that options are added only once, it turns out our parsing code was adding them multiple times.
In general usage this was not an issue because the parse is only called once.
In test usage this causes a problem because parse is called repeatedly by different test combinations.

## Approach

* Create a `new Command()` for each of `backupProgram` and `restoreProgram`.
* Call the `cliDefaults()` once instead of in each parse function.
* Move the configuration of the CLI flag options out of the parse functions and onto the `const`s that define the `backup` or `restore` commands.

With these changes the options are configured only once and the tests pass, both here and with commander 15.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because covered by existing tests

## Monitoring and Logging

- "No change"
