### PR TITLE
Prepare 2.11.18 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 # 2.11.18 (2026-06-22)
-- [NOTE] Updated minimum supported engine to Node.js 22 LTS.
 - [UPGRADED] `commander` dependency to version `15.0.0`.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.22`.
 - [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.4.22` to match version provided from `@ibm-cloud/cloudant`.
 - [UPGRADED] `axios` peerDependency to version `1.18.0` to match version provided from `@ibm-cloud/cloudant`.
+- [NOTE] Updated minimum supported engine to Node.js 22 LTS.
 
 # 2.11.17 (2026-04-28)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.19`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
-# Unreleased
+# 2.11.18 (2026-06-22)
 - [NOTE] Updated minimum supported engine to Node.js 22 LTS.
+- [UPGRADED] `commander` dependency to version `15.0.0`.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.22`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.4.22` to match version provided from `@ibm-cloud/cloudant`.
+- [UPGRADED] `axios` peerDependency to version `1.18.0` to match version provided from `@ibm-cloud/cloudant`.
 
 # 2.11.17 (2026-04-28)
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.19`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.18-SNAPSHOT",
+  "version": "2.11.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.18-SNAPSHOT",
+      "version": "2.11.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.18-SNAPSHOT",
+  "version": "2.11.18",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.18 release

# Changes
<!-- Paste the changes information here -->
# 2.11.18 (2026-06-22)
- [NOTE] Updated minimum supported engine to Node.js 22 LTS.
- [UPGRADED] `commander` dependency to version `15.0.0`.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.22`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.4.22` to match version provided from `@ibm-cloud/cloudant`.
- [UPGRADED] `axios` peerDependency to version `1.18.0` to match version provided from `@ibm-cloud/cloudant`.