### PR TITLE
fix: validate option types before log/resume validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2024 IBM Corp. All rights reserved.
+// Copyright © 2017, 2026 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ function isSafePositiveInteger(x) {
  * @param {boolean} isIAM - A flag if IAM authentication been used.
  * @returns Boolean true if all checks are passing.
  */
-async function validateURL(url, isIAM) {
+function validateURL(url, isIAM) {
   if (typeof url !== 'string') {
     throw new OptionError('Invalid URL, must be type string');
   }
@@ -83,7 +83,7 @@ async function validateURL(url, isIAM) {
  * @param {object} opts - Options.
  * @returns Boolean true if all checks are passing.
  */
-async function validateOptions(opts) {
+function validateOptions(opts) {
   // if we don't have opts then we'll be using defaults
   if (!opts) {
     return true;
@@ -139,7 +139,7 @@ async function validateOptions(opts) {
  *
  * @param {object} opts - Options.
  */
-async function shallowModeWarnings(opts) {
+function shallowModeWarnings(opts) {
   if (!opts || opts.mode !== 'shallow') {
     return;
   }
@@ -161,7 +161,7 @@ async function shallowModeWarnings(opts) {
  * @returns Boolean true if all checks are passing.
  */
 
-async function validateLogOnResume(opts) {
+function validateLogOnResume(opts) {
   const logFileExists = opts && opts.log && fs.existsSync(opts.log);
   if (!opts || opts.mode === 'shallow') {
     // No opts specified, defaults will be populated.
@@ -190,7 +190,7 @@ async function validateLogOnResume(opts) {
   return true;
 }
 
-async function attachmentWarnings(opts) {
+function attachmentWarnings(opts) {
   if (opts && opts.attachments) {
     console.warn('WARNING: The "attachments" option is provided as-is and is not supported. ' +
       'This option is for Apache CouchDB only and is experimental. ' +
@@ -204,22 +204,18 @@ async function attachmentWarnings(opts) {
  * @param {string} url - URL of database.
  * @param {object} opts - Options.
  * @param {boolean} backup - true for backup, false for restore
- * @returns Boolean true if all checks are passing.
+ * @returns {Promise<boolean>} `true` if all checks are passing, otherwise rejected.
  */
 async function validateArgs(url, opts, isBackup = true) {
   const isIAM = opts && typeof opts.iamApiKey === 'string';
-  const validations = [
-    validateURL(url, isIAM),
-    validateOptions(opts),
-    attachmentWarnings(opts)
-  ];
+  validateURL(url, isIAM);
+  validateOptions(opts);
+  attachmentWarnings(opts);
   if (isBackup) {
-    validations.push(
-      shallowModeWarnings(opts),
-      validateLogOnResume(opts)
-    );
+    shallowModeWarnings(opts);
+    validateLogOnResume(opts);
   }
-  return Promise.all(validations);
+  return true;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Avoid `(node:240) [DEP0187] DeprecationWarning: Passing invalid argument types to fs.existsSync is deprecated`
Fixes i585
## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
The option validations are executed within a `Promise.all()`, so `validateOptions` may not complete before `validateLogOnResume`. As a result, `fs.existsSync()` is being called with invalid arguments, which triggers the deprecation warning.  The fix splits the validations into two sequential await `Promise.all()` calls. Type checks first, then the log/resume validation, so invalid types are caught before `fs.existsSync()` is reached.
## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"
## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

- N/A build or packaging only changes
## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"