### PR TITLE
ci: add stage to auto-update peerDependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,6 +191,10 @@ def runTest(version, filter, testSuite, reportName, iamAuth) {
   }
 }
 
+def sdkVersion
+def coreVersion
+def axiosVersion
+
 pipeline {
   agent {
     kubernetes {
@@ -220,6 +224,48 @@ pipeline {
           withEnv(['NPMRC_EMAIL=' + env.NPMRC_USER]) {
             withNpmEnv(registryArtifactoryDown) {
               sh 'npm ci'
+            }
+          }
+        }
+      }
+    }
+    stage('Update peerDependencies') {
+      when {
+        beforeAgent true
+        branch pattern: 'dependabot/npm_and_yarn/ibm-cloud/cloudant-\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+        environment name: 'BUILD_NUMBER', value: '1'
+        expression {
+          sh(returnStatus: true, script: '''
+            ! git diff HEAD~1 --name-only | grep -qvE '^package(-lock)?\\.json$' &&
+            git diff HEAD~1 -- package.json | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -q '@ibm-cloud/cloudant'
+          ''') == 0
+        }
+      }
+      steps {
+        script {
+          sdkVersion = sh(returnStdout: true, script: "jq -r '.dependencies.\"@ibm-cloud/cloudant\"' package.json").trim()
+        }
+        withCredentials([usernamePassword(usernameVariable: 'NPMRC_USER', passwordVariable: 'NPMRC_TOKEN', credentialsId: 'artifactory')]) {
+          withEnv(['NPMRC_EMAIL=' + env.NPMRC_USER]) {
+            withNpmEnv(registryArtifactoryDown) {
+              script {
+                coreVersion = sh(returnStdout: true, script: "npm view @ibm-cloud/cloudant@${sdkVersion} dependencies.ibm-cloud-sdk-core").trim()
+                axiosVersion = sh(returnStdout: true, script: "npm view ibm-cloud-sdk-core@${coreVersion} dependencies.axios").trim()
+              }
+              sh "npm install --save-exact --save-peer axios@${axiosVersion} ibm-cloud-sdk-core@${coreVersion}"
+            }
+          }
+        }
+        sh """sed -i -E 's|"resolved": "${getRegistryArtifactoryDown()}([^"?]+)\\?dl=https%3A%2F%2F[^"]*"|"resolved": "${getRegistryPublic()}\\1"|g' package-lock.json"""
+        gitsh('github.com') {
+          script {
+            def diffStatus = sh(returnStatus: true, script: 'git diff --quiet package.json package-lock.json')
+            if (diffStatus == 1) {
+              sh 'git add package.json package-lock.json'
+              sh "git commit -m 'chore: update peerDependencies for @ibm-cloud/cloudant@${sdkVersion}'"
+              sh "git push origin HEAD:${env.BRANCH_NAME}"
+            } else {
+              echo 'No peerDependency changes to commit'
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "debug": "4.4.3"
   },
   "peerDependencies": {
-    "ibm-cloud-sdk-core": "5.5.0",
-    "axios": "1.18.0"
+    "axios": "1.18.0",
+    "ibm-cloud-sdk-core": "5.5.0"
   },
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Added `Update peerDependencies` stage to Jenkinsfile to auto-update `cloudant-node-sdk` peer dependencies.
Fixes i596
## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
- Added a Jenkins stage that only runs for `cloudant-node-sdk` Dependabot update branches.
- The stage is gated by `when` conditions to ensure it only executes on the initial build and only for the expected dependency update.
- The SDK version is read from the Dependabot update and used to determine the corresponding `ibm-cloud-sdk-core` and `axios` versions.
- The peer dependencies are then updated to the versions required by the updated SDK.
## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"
## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

- "No change"
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
- N/A build or packaging only changes
## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"