### PR TITLE
ci: use changeRequest instead of branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,7 +232,7 @@ pipeline {
     stage('Update peerDependencies') {
       when {
         beforeAgent true
-        branch pattern: 'dependabot/npm_and_yarn/ibm-cloud/cloudant-\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+        changeRequest branch: 'dependabot/npm_and_yarn/ibm-cloud/cloudant-\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
         environment name: 'BUILD_NUMBER', value: '1'
         expression {
           sh(returnStatus: true, script: '''
@@ -262,7 +262,7 @@ pipeline {
             if (diffStatus == 1) {
               sh 'git add package.json package-lock.json'
               sh "git commit -m 'chore: update peerDependencies for @ibm-cloud/cloudant@${sdkVersion}'"
-              sh "git push origin HEAD:${env.BRANCH_NAME}"
+              sh "git push origin HEAD:${env.CHANGE_BRANCH}"
             } else {
               echo 'No peerDependency changes to commit'
             }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - build change
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes - build change
- [x] Completed the PR template below:

## Description

Use the PR (changeRequest) build instead of the branch build to do the peerDependencies updates.

Fixes part of i596

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

See https://github.com/IBM/couchbackup/pull/977

### 2. What you expected to happen

Expected peer dep update from the stage added in #971 

### 3. What actually happened

There was no branch build only a PR build so the stage was skipped and the update didn't happen until I replayed it with these changes.

## Approach

* Switch the `branch` when condition to a `changeRequest branch:` one
* Update the push to use `env.CHANGE_BRANCH` instead of `env.BRANCH_NAME`

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"


## Testing

- N/A build or packaging only changes, but tested the `Jenkinsfile` change in a replay

## Monitoring and Logging

- "No change"
