### PR TITLE
Prepare 2.11.19 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.11.19 (2026-08-19)
+- [FIXED] Option validation to prevent `[DEP0187] DeprecationWarning` from `fs.existsSync` when invalid types are passed.
+- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.24`.
+- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.5.0` to match version provided from `@ibm-cloud/cloudant`.
+
 # 2.11.18 (2026-06-22)
 - [UPGRADED] `commander` dependency to version `15.0.0`.
 - [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.22`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.19-SNAPSHOT",
+  "version": "2.11.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudant/couchbackup",
-      "version": "2.11.19-SNAPSHOT",
+      "version": "2.11.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/cloudant": "0.12.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/couchbackup",
-  "version": "2.11.19-SNAPSHOT",
+  "version": "2.11.19",
   "description": "CouchBackup - command-line backup utility for Cloudant/CouchDB",
   "homepage": "https://github.com/IBM/couchbackup",
   "repository": {


### PR DESCRIPTION
# Proposed 2.11.19 release

# Changes

# 2.11.19 (2026-08-19)
- [FIXED] Option validation to prevent `[DEP0187] DeprecationWarning` from `fs.existsSync` when invalid types are passed.
- [UPGRADED] `@ibm-cloud/cloudant` dependency to version `0.12.24`.
- [UPGRADED] `ibm-cloud-sdk-core` peerDependency to version `5.5.0` to match version provided from `@ibm-cloud/cloudant`.
